### PR TITLE
update the node positions as reactflow changes them

### DIFF
--- a/src/components/toolbar.tsx
+++ b/src/components/toolbar.tsx
@@ -1,5 +1,5 @@
 
-import { Instance } from "mobx-state-tree";
+import { Instance, getSnapshot } from "mobx-state-tree";
 import React from "react";
 import { DQRoot } from "../models/dq-root";
 
@@ -14,7 +14,8 @@ export const ToolBar: React.FC<IProps> = ({dqRoot}) => {
     };
     
     const copyDiagramURL = () => {
-        const exportedDiagram = dqRoot.getDiagramState();
+        const exportedDiagram = getSnapshot(dqRoot);
+        console.log("Exported Diagram", exportedDiagram);
         const url = new URL(window.location.href);
         url.searchParams.set("diagram", JSON.stringify(exportedDiagram));
         console.log(url.href);

--- a/src/models/dq-node.ts
+++ b/src/models/dq-node.ts
@@ -258,5 +258,12 @@ export const DQNode = types.model("BasicNode", {
         },
         setOperation(newOperation?: Operation) {
             self.operation = newOperation;
+        },
+        // Note: as far as I know React Flow will ignore this change
+        // it only pays attention to the position of the node when the
+        // diagram is first initialized
+        updatePosition(x: number, y: number) {
+            self.x = x;
+            self.y = y;
         }
     }));

--- a/src/models/dq-root.ts
+++ b/src/models/dq-root.ts
@@ -1,13 +1,10 @@
-import { Instance, types, destroy, getSnapshot } from "mobx-state-tree";
-import { Elements, isNode, OnLoadParams } from "react-flow-renderer/nocss";
+import { Instance, types, destroy } from "mobx-state-tree";
+import { Elements } from "react-flow-renderer/nocss";
 import { DQNode } from "./dq-node";
 
 export const DQRoot = types.model("DQRoot", {
     nodes: types.map(DQNode)
 })
-.volatile(self => ({
-    rfInstance: undefined as OnLoadParams | undefined
-}))
 .views(self => ({
     get reactFlowElements() {
         const elements: Elements = [];
@@ -15,26 +12,7 @@ export const DQRoot = types.model("DQRoot", {
             elements.push(...node.reactFlowElements);
         });
         return elements;
-    },
-    // NOTE: this is not reactive, so components accessing it won't be re-rendered
-    // automatically if the value changes
-    getDiagramState() {
-        const currentSnapshot = getSnapshot(self);
-        const currentModel = JSON.parse(JSON.stringify(currentSnapshot));
-        const currentDiagram = self.rfInstance?.toObject();
-        if (!currentDiagram) {
-          return;
-        }
-        for(const node of currentDiagram.elements) {
-          if (isNode(node)) {
-            const modelNode = currentModel.nodes[node.id];
-            modelNode.x = node.position.x;
-            modelNode.y = node.position.y;
-          }
-        }
-        console.log("Exported Diagram", currentModel);
-        return currentModel;
-    }  
+    }
 }))
 .actions(self => ({
     addNode(newNode: Instance<typeof DQNode>) {
@@ -44,8 +22,5 @@ export const DQRoot = types.model("DQRoot", {
         const nodeToRemove = self.nodes.get(nodeId);
         // self.nodes.delete(nodeId);
         destroy(nodeToRemove);
-    },
-    setRfInstance(rfInstance: OnLoadParams) {
-        self.rfInstance = rfInstance;
     }
 }));


### PR DESCRIPTION
this has two benefits:
- it simplifies the serialization
- CODAP can just monitor the tree to see changes