### PR TITLE
Simplify import code

### DIFF
--- a/src/diagram/models/dq-node.test.ts
+++ b/src/diagram/models/dq-node.test.ts
@@ -1,0 +1,15 @@
+import { DQNode } from "./dq-node";
+
+describe("DQNode", () => {
+  it("can be instantiated with undefined value", () => {
+    const node = DQNode.create({ x: 0, y: 0 });
+    // but null is converted to undefined automatically via import
+    expect(node.value).toBeUndefined();
+  });
+  it("can't be instantiated with null value but can import null values", () => {
+    // @ts-expect-error null value on create results in TypeScript error
+    const node = DQNode.create({ value: null, x: 0, y: 0 });
+    // but null is converted to undefined automatically via import
+    expect(node.value).toBeUndefined();
+  });
+});


### PR DESCRIPTION
In the [prior PR](https://github.com/concord-consortium/quantity-playground/pull/6), @scytacki commented:

>We should dig into this more. If the value is coming up null in some places then the unit and name could also show up as null.
>
>If we do have to handle this, making an additional ImportableDQNode seems heavy when we could just do this a couple of lines in the preProcessor function.
>
>If the point is so that typescript can validate the snapshots we probably should stick with not allowing null in any typescript validated snapshots. And we just have this special null handling until we can figure out where it is coming from.
>
>But I'm going to merge this and we can look at this later.

I spent some time playing around with alternative ways of specifying the plausible import types using the recommended `snapshotProcessor` approach, but then I also noticed that the `snapshotProcessor` approach results in widening the client-visible snapshot interface, when we only want to widen the importable snapshot interface without widening the client-visible interface. Therefore, I'm reverting back to the now-deprecated `preprocessSnapshot` approach which serves our needs much better and is much simpler, despite being deprecated. 🤷 