### PR TITLE
Closes Expression Editor when user clicks out side the dialog.

### DIFF
--- a/src/diagram/components/expression-editor.scss
+++ b/src/diagram/components/expression-editor.scss
@@ -1,5 +1,4 @@
 .expression-editor-dialog {
-  height: 125px;
   width: 510px;
   position: absolute;
   top: 85px;

--- a/src/diagram/components/expression-editor.test.tsx
+++ b/src/diagram/components/expression-editor.test.tsx
@@ -145,4 +145,50 @@ describe("Expression Editor", () => {
     userEvent.click(screen.getByTestId("expression-editor-apply-button"));
     expect(nodeExpressionVar.variable.expression).toBe("9+9");
   });
+  it("expression editor should save its value when user hits Enter", () => {
+    const inputA = Variable.create({id: "inputA", value: 999, unit: "m"});
+    const expressionVar = Variable.create({id: "expressionVar", inputA: "inputA"});
+    const root = DQRoot.create();
+    const nodeA = DQNode.create({ variable: inputA.id, x: 0, y: 0 });
+    const nodeExpressionVar = DQNode.create({ variable: expressionVar.id, x: 10, y: 10 });
+    const container = GenericContainer.create({
+      items: [
+        {id: "inputA", value: 999, unit: "m"},
+        {id: "expressionVar", value: 123.5, inputA: "inputA"}
+      ]
+    });
+    root.addNode(nodeA);
+    root.addNode(nodeExpressionVar);
+    container.setRoot(root);
+    render(<Diagram dqRoot={root} />);
+
+    expect(screen.getByTestId("variable-expression-edit-button")).toBeInTheDocument();
+    userEvent.click(screen.getByTestId("variable-expression-edit-button"));
+    expect(screen.getByTestId("expression-editor-input-field")).toBeInTheDocument();
+    userEvent.type(screen.getByTestId("expression-editor-input-field"), "9+9{enter}");
+    expect(nodeExpressionVar.variable.expression).toBe("9+9");
+  });
+  it("expression editor does not save its value when user hits Esc", () => {
+    const inputA = Variable.create({id: "inputA", value: 999, unit: "m"});
+    const expressionVar = Variable.create({id: "expressionVar", inputA: "inputA"});
+    const root = DQRoot.create();
+    const nodeA = DQNode.create({ variable: inputA.id, x: 0, y: 0 });
+    const nodeExpressionVar = DQNode.create({ variable: expressionVar.id, x: 10, y: 10 });
+    const container = GenericContainer.create({
+      items: [
+        {id: "inputA", value: 999, unit: "m"},
+        {id: "expressionVar", value: 123.5, inputA: "inputA"}
+      ]
+    });
+    root.addNode(nodeA);
+    root.addNode(nodeExpressionVar);
+    container.setRoot(root);
+    render(<Diagram dqRoot={root} />);
+
+    expect(screen.getByTestId("variable-expression-edit-button")).toBeInTheDocument();
+    userEvent.click(screen.getByTestId("variable-expression-edit-button"));
+    expect(screen.getByTestId("expression-editor-input-field")).toBeInTheDocument();
+    userEvent.type(screen.getByTestId("expression-editor-input-field"), "9+9{esc}");
+    expect(nodeExpressionVar.variable.expression).toBe(undefined);
+  });
 });

--- a/src/diagram/components/expression-editor.tsx
+++ b/src/diagram/components/expression-editor.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { useClickAway } from "../../hooks/use-click-away";
 import { VariableType } from "../models/variable";
 
 import "./expression-editor.scss";
@@ -10,13 +11,13 @@ interface IProps {
 
 export const ExpressionEditor: React.FC<IProps> = ({variable, onShowExpressionEditor}) => {
   const [appliedExpression, setAppliedExpression] = useState(variable.expression);
-  const expressionEditorRef = useRef<HTMLTextAreaElement | null>(null);
+  const expressionEditorTextAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
-    if (expressionEditorRef?.current) {
-      expressionEditorRef.current.style.height = "0px";
-      const scrollHeight = expressionEditorRef.current.scrollHeight;
-      expressionEditorRef.current.style.height = scrollHeight + "px";
+    if (expressionEditorTextAreaRef?.current) {
+      expressionEditorTextAreaRef.current.style.height = "0px";
+      const scrollHeight = expressionEditorTextAreaRef.current.scrollHeight;
+      expressionEditorTextAreaRef.current.style.height = scrollHeight + "px";
     }
   }, [variable.expression]);
 
@@ -24,6 +25,8 @@ export const ExpressionEditor: React.FC<IProps> = ({variable, onShowExpressionEd
     setAppliedExpression(variable.expression);
     onShowExpressionEditor(false);
   };
+  const expressionEditorDialogRef = useClickAway(handleCloseEditor);
+
   const handleCancelEditor = () => {
     variable.setExpression(appliedExpression);
     onShowExpressionEditor(false);
@@ -33,26 +36,31 @@ export const ExpressionEditor: React.FC<IProps> = ({variable, onShowExpressionEd
     variable.setExpression(evt.target.value || undefined);
   };
 
-  const handleEnter = (evt: any) => {
-    if (evt.key === "Enter") {
-      handleCloseEditor();
+  const handleKeyDown = (evt: any) => {
+    switch (evt.key) {
+      case "Enter":
+        handleCloseEditor();
+        break;
+      case "Escape":
+        handleCancelEditor();
+        break;
     }
   };
 
   return (
-    <div className={"expression-editor-dialog"} data-testid="expression-editor-dialog">
+    <div ref={expressionEditorDialogRef} className={"expression-editor-dialog"} data-testid="expression-editor-dialog">
       <div className="title">Expression Editor</div>
       <div className="expression-editor-container">
         <div className="variable-name">{variable.name || "variable"}=</div>
         <textarea className="expression-editor"
-                  ref={expressionEditorRef}
+                  ref={expressionEditorTextAreaRef}
                   rows={1}
                   placeholder="expression"
                   value={variable.expression || ""}
                   data-testid="expression-editor-input-field"
                   onMouseDown={e => e.stopPropagation()}
                   onChange={handleExpressionChange}
-                  onKeyDown={handleEnter}
+                  onKeyDown={handleKeyDown}
         >
           {variable.expression || ""}
         </textarea>

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -93,8 +93,10 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
         id="b"
       />
       <div className="variable-info-container">
-        <input className="variable-info name" type="text" placeholder="name" value={variable.name || ""} data-testid="variable-name"
+        <div className="variable-info-row">
+          <input className="variable-info name" type="text" placeholder="name" autoComplete="off" value={variable.name || ""} data-testid="variable-name"
             onMouseDown={e => e.stopPropagation()} onChange={onNameChange} />
+        </div>
         {variable.numberOfInputs >= 1 &&
           <div className="variable-info-row">
             <div className="variable-info expression" placeholder="expression" data-testid="variable-expression">{variable.expression || ""}</div>
@@ -104,9 +106,9 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
           </div>
         }
         <div className="variable-info-row">
-          <input className="variable-info value" type="number" placeholder="value" onChange={onValueChange} data-testid="variable-value"
+          <input className="variable-info value" type="number" placeholder="value" autoComplete="off" onChange={onValueChange} data-testid="variable-value"
             value={shownValue !== undefined ? shownValue.toString() : ""} onMouseDown={e => e.stopPropagation()} />
-          <input className="variable-info unit" type="text" placeholder="unit" value={shownUnit|| ""} data-testid="variable-unit"
+          <input className="variable-info unit" type="text" placeholder="unit" autoComplete="off" value={shownUnit|| ""} data-testid="variable-unit"
             onChange={onUnitChange} onMouseDown={e => e.stopPropagation()} />
         </div>
         <div>

--- a/src/hooks/use-click-away.ts
+++ b/src/hooks/use-click-away.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from "react";
+
+export const useClickAway = (callback: () => void) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClick = (event: { target: any; }) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback();
+      }
+    };
+
+    document.addEventListener("click", handleClick, true);
+
+    return () => {
+      document.removeEventListener("click", handleClick, true);
+    };
+  }, [callback, ref]);
+
+  return ref;
+};


### PR DESCRIPTION
Disables input autofill
Resizes expression editor when the textarea expands.
Escape key closes the expression editor and acts like the Cancel button.
Name field no longer expands when expression field expands.