### PR TITLE
[#181614001] Variable description can be entered by the user.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react": "^17.0.2",
         "react-color": "^2.19.3",
         "react-dom": "^17.0.2",
-        "react-flow-renderer": "^9.7.4"
+        "react-flow-renderer": "^9.7.4",
+        "react-textarea-autosize": "^8.3.4"
       },
       "devDependencies": {
         "@cypress/code-coverage": "^3.9.11",
@@ -15269,6 +15270,33 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-textarea-autosize/node_modules/@babel/runtime": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
@@ -18104,6 +18132,43 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util": {
@@ -30875,6 +30940,26 @@
         }
       }
     },
+    "react-textarea-autosize": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+          "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
@@ -33073,6 +33158,26 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
+    },
+    "use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      }
     },
     "util": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react": "^17.0.2",
     "react-color": "^2.19.3",
     "react-dom": "^17.0.2",
-    "react-flow-renderer": "^9.7.4"
+    "react-flow-renderer": "^9.7.4",
+    "react-textarea-autosize": "^8.3.4"
   }
 }

--- a/src/diagram/components/quantity-node.scss
+++ b/src/diagram/components/quantity-node.scss
@@ -154,4 +154,16 @@ $gray-mid: #bcbcbc;
     padding: 2px 6px;
     border: 0 solid #999;
   }
+
+  .variable-description-area {
+    resize: none;
+    width: 100%;
+    text-align-last:left!important;
+    border-radius: 5px;
+    border: none;
+    margin: 3px;
+    padding-left: .5em;
+    padding-right: .5em;
+    overscroll-behavior-y: auto;
+  }
 }

--- a/src/diagram/components/quantity-node.scss
+++ b/src/diagram/components/quantity-node.scss
@@ -164,6 +164,18 @@ $gray-mid: #bcbcbc;
     margin: 3px;
     padding-left: .5em;
     padding-right: .5em;
-    overscroll-behavior-y: auto;
+    overflow-y: scroll;
+  }
+  /* Make scrollbar always visible when active:
+   * https://stackoverflow.com/questions/1202425/making-the-main-scrollbar-always-visible
+   */
+  .variable-description-area::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+  }
+  .variable-description-area::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, .5);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
   }
 }

--- a/src/diagram/components/quantity-node.test.tsx
+++ b/src/diagram/components/quantity-node.test.tsx
@@ -64,12 +64,15 @@ describe("Quantity Node", () => {
     const nameTextBox = screen.getByTestId("variable-name");
     const valueTextBox = screen.getByTestId("variable-value");
     const unitTextBox = screen.getByTestId("variable-unit");
+    const descriptionTextBox = screen.getByTestId("variable-description");
     await userEvent.type(nameTextBox, "my variable name");
     await userEvent.type(valueTextBox, "45");
     await userEvent.type(unitTextBox, "miles");
+    await userEvent.type(descriptionTextBox, "a\ndescription")
     expect(variable.name).toBe("my variable name");
     expect(variable.value).toEqual(45);
     expect(variable.unit).toBe("miles");
+    expect(variable.description).toBe("a\ndescription");
 
     //verify cannot enter a non-digit into value input
     await userEvent.type(valueTextBox, "letter");

--- a/src/diagram/components/quantity-node.test.tsx
+++ b/src/diagram/components/quantity-node.test.tsx
@@ -68,7 +68,7 @@ describe("Quantity Node", () => {
     await userEvent.type(nameTextBox, "my variable name");
     await userEvent.type(valueTextBox, "45");
     await userEvent.type(unitTextBox, "miles");
-    await userEvent.type(descriptionTextBox, "a\ndescription")
+    await userEvent.type(descriptionTextBox, "a\ndescription");
     expect(variable.name).toBe("my variable name");
     expect(variable.value).toEqual(45);
     expect(variable.unit).toBe("miles");
@@ -92,7 +92,7 @@ describe("Quantity Node", () => {
     const colorSelectButton = screen.getByTestId("color-edit-button");
     await userEvent.click(colorSelectButton);
     expect(screen.getByTitle("color picker")).toBeInTheDocument();
-    await userEvent.click(screen.getByTitle("#9900EF"))
+    await userEvent.click(screen.getByTitle("#9900EF"));
     expect(variable.color).toBe("#9900ef");
   });
 });

--- a/src/diagram/components/quantity-node.test.tsx
+++ b/src/diagram/components/quantity-node.test.tsx
@@ -78,4 +78,21 @@ describe("Quantity Node", () => {
     await userEvent.type(valueTextBox, "letter");
     expect(variable.value).toBe(undefined);
   });
+  it("can edit a variable color", async () => {
+    const variable = Variable.create({});
+    expect(variable.color).toBe("#e98b42");
+    const root = DQRoot.create();
+    const node = DQNode.create({ variable: variable.id, x: 0, y: 0 });
+    root.addNode(node);
+    const container = GenericContainer.create();
+    container.add(variable);
+    container.setRoot(root);
+    render(<Diagram dqRoot={root} />);
+    expect(screen.getByTestId("variable-name")).toBeInTheDocument();
+    const colorSelectButton = screen.getByTestId("color-edit-button");
+    await userEvent.click(colorSelectButton);
+    expect(screen.getByTitle("color picker")).toBeInTheDocument();
+    await userEvent.click(screen.getByTitle("#9900EF"))
+    expect(variable.color).toBe("#9900ef");
+  });
 });

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -6,6 +6,7 @@ import { DQNodeType } from "../models/dq-node";
 import { DQRootType } from "../models/dq-root";
 import { ExpressionEditor } from "./expression-editor";
 import { ColorEditor } from "./color-editor";
+import TextareaAutosize from "react-textarea-autosize";
 
 import "./quantity-node.scss";
 
@@ -96,6 +97,14 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     }
   };
 
+  const onDescriptionChange = (evt: any) => {
+    if (!evt.target.value) {
+      variable.setDescription(undefined);
+    } else {
+      variable.setDescription(evt.target.value);
+    }
+  };
+
   const renderValueUnitInput = () => {
     return (
       <div className="variable-info-row">
@@ -144,6 +153,11 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
           </div>
         }
         {hasExpression ? renderValueUnitUnEditable() : renderValueUnitInput()}
+        <div className="variable-info-row">
+          <TextareaAutosize className="variable-description-area"
+                            onChange={onDescriptionChange} minRows={1}
+                            maxRows={4}  placeholder={"description"} data-testid={"variable-description"}/>
+        </div>
         { variable.computedValueError &&
           <div className="error-message">
               ⚠️ {variable.computedValueError}

--- a/src/diagram/models/variable.test.ts
+++ b/src/diagram/models/variable.test.ts
@@ -728,6 +728,7 @@ describe("Variable", () => {
     variable.setUnit("m");
     variable.setName("my variable");
     variable.setOperation(Operation.Add);
+    variable.setDescription("This is my variable")
 
     expect(getSnapshot(variable)).toEqual({
       id: expect.stringMatching(/^.{16}$/),
@@ -736,7 +737,8 @@ describe("Variable", () => {
       unit: "m",
       name: "my variable",
       operation: "+",
-      color: "#e98b42"
+      color: "#e98b42",
+      description: "This is my variable"
     });
   });
 

--- a/src/diagram/models/variable.test.ts
+++ b/src/diagram/models/variable.test.ts
@@ -728,7 +728,7 @@ describe("Variable", () => {
     variable.setUnit("m");
     variable.setName("my variable");
     variable.setOperation(Operation.Add);
-    variable.setDescription("This is my variable")
+    variable.setDescription("This is my variable");
 
     expect(getSnapshot(variable)).toEqual({
       id: expect.stringMatching(/^.{16}$/),

--- a/src/diagram/models/variable.ts
+++ b/src/diagram/models/variable.ts
@@ -25,6 +25,7 @@ export interface IVariable  { // build needs to know dq-node to have access to t
 export const Variable = types.model("Variable", {
   id: types.optional(types.identifier, () => nanoid(16)),
   name: types.maybe(types.string),
+  description: types.maybe(types.string),
   unit: types.maybe(types.string),
   // null values have been seen in the implementation
   // hopefully we can track down where those come from instead of making this
@@ -351,6 +352,9 @@ export const Variable = types.model("Variable", {
   },
   setName(newName?: string) {
     self.name = newName;
+  },
+  setDescription(newDescription?: string) {
+    self.description = newDescription;
   },
   setOperation(newOperation?: Operation) {
     self.operation = newOperation;


### PR DESCRIPTION
* The story describes the description text area as a part of
  the expanded Card. That story (#181613891) has not been
  worked on yet, so this places the edit field in the normal
  sized card.
  Presumably, the element will be simply migrated to the expanded
  card when it exists.
* The description field can easily run below the bottom of the
  card. I thought about expanding the card in response, but this
  effort would likely be undone by the expanded card story, so
  this issue is left unaddressed.
* Other editable fields in the card are right aligned. It felt
  wrong typing into a right aligned text area, so I left it left-
  aligned. Can be easily changed, though.
* The description field grows to four lines, and then becomes
  scrollable.