### PR TITLE
Update yalc local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Alternately, you can run secure without certificates in Chrome:
 2. Change flag from disabled to enabled
 3. Run `npm run start:secure:no-certs` to run `webpack-dev-server` in development mode with hot module replacement
 
+### Testing in CLUE and other projects
+
+The diagram-view is used in CLUE in the diagram tile, and possibly other projects as well. As you're making changes to this library, it can be helpful to test those changes within client projects without deploying. For more on this, see README.md in the diagram-view directory.
+
 ### Building
 
 If you want to build a local version run `npm build`, it will create the files in the `dist` folder.
@@ -61,19 +65,6 @@ To deploy a production release:
     2. Click the "Run workflow" menu button. 
     3. Type in the tag name you want to release for example `v1.2.3`.  (Note this won't work until the PR has been merged to master)
     4. Click the `Run Workflow` button.
-
-### Testing in CLUE
-
-The diagram-view is used in CLUE in the diagram tile, and it can be useful to test changes made in Quantity Playground in CLUE without deploying updates. To do so, it's best to use `yalc`.
-
-1. Install Yalc by running `sudo npm install --global yalc`.
-2. Install Rollup by running `sudo npm install --global rollup`.
-3. In the `diagram-view` folder, run `yalc publish`.
-4. In your `collaborative-learning` directory, run `yalc add @concord-consortium/diagram-view`.
-
-After you're happy with your changes and have deployed a new version of Quantity Playground, make sure you revert to using the published version by running `yalc remove @concord-consortium/diagram-view` in your `collaborative-learning` directory.
-
-For more information, see `README.md` in the `diagram-view` directory.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ To deploy a production release:
     3. Type in the tag name you want to release for example `v1.2.3`.  (Note this won't work until the PR has been merged to master)
     4. Click the `Run Workflow` button.
 
+### Testing in CLUE
+
+The diagram-view is used in CLUE in the diagram tile, and it can be useful to test changes made in Quantity Playground in CLUE without deploying updates. To do so, it's best to use `yalc`.
+
+1. Install Yalc by running `sudo npm install --global yalc`.
+2. Install Rollup by running `sudo npm install --global rollup`.
+3. In the `diagram-view` folder, run `yalc publish`.
+4. In your `collaborative-learning` directory, run `yalc add @concord-consortium/diagram-view`.
+
+After you're happy with your changes and have deployed a new version of Quantity Playground, make sure you revert to using the published version by running `yalc remove @concord-consortium/diagram-view` in your `collaborative-learning` directory.
+
 ### Testing
 
 Run `npm test` to run jest tests. Run `npm run test:full` to run jest and Cypress tests.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The diagram-view is used in CLUE in the diagram tile, and it can be useful to te
 
 After you're happy with your changes and have deployed a new version of Quantity Playground, make sure you revert to using the published version by running `yalc remove @concord-consortium/diagram-view` in your `collaborative-learning` directory.
 
+For more information, see `README.md` in the `diagram-view` directory.
+
 ### Testing
 
 Run `npm test` to run jest tests. Run `npm run test:full` to run jest and Cypress tests.

--- a/diagram-view/README.md
+++ b/diagram-view/README.md
@@ -2,12 +2,6 @@
 
 [yalc](https://www.npmjs.com/package/yalc) provides an alternative to `npm link`. It acts as a very simple local repository for locally developed packages that can be shared across a local environment. It provides a better workflow than `npm | yarn link` for package authors. There are scripts in package.json to make this easier.
 
-To start, install yalc and rollup:
-```
-$ sudo npm install --global yalc
-$ sudo npm install --global rollup
-```
-
 To publish an in-development version of the diagram-view library, in this diagram-view directory run:
 ```
 $ npm run yalc:publish

--- a/diagram-view/README.md
+++ b/diagram-view/README.md
@@ -1,6 +1,12 @@
-#### Using yalc to test this is CLUE
+#### Using yalc to test the diagram-view in CLUE
 
-[yalc](https://www.npmjs.com/package/yalc) provides an alternative to `npm link`. It acts as a very simple local repository for locally developed packages that can be shared across a local environment. It provides a better workflow than `npm | yarn link` for package authors. There are scripts in package.json to make this easier. 
+[yalc](https://www.npmjs.com/package/yalc) provides an alternative to `npm link`. It acts as a very simple local repository for locally developed packages that can be shared across a local environment. It provides a better workflow than `npm | yarn link` for package authors. There are scripts in package.json to make this easier.
+
+To start, install yalc and rollup:
+```
+$ sudo npm install --global yalc
+$ sudo npm install --global rollup
+```
 
 To publish an in-development version of the diagram-view library, in this diagram-view directory run:
 ```

--- a/diagram-view/rollup.config.mjs
+++ b/diagram-view/rollup.config.mjs
@@ -8,7 +8,7 @@ import typescript from "rollup-plugin-typescript2";
 import commonjs from "@rollup/plugin-commonjs";
 import postcss from "rollup-plugin-postcss";
 
-import packageJson from "./package.json";
+import packageJson from "./package.json" assert { type: "json" };
 
 export default [
   {
@@ -44,7 +44,7 @@ export default [
       postcss({
         extract: path.resolve("dist/index.css")
       }),
-      visualizer({ open: false }), // <== set to true to automatically open visualizer on build
+      // visualizer({ open: false }), // <== set to true to automatically open visualizer on build
     ]
   },
   { // bundle declaration files


### PR DESCRIPTION
This PR updates rollout.config to work with the latest versions of yalc and rollout. It also adds instructions to the readme for testing changes in CLUE without deploying a new version of quantity playground.