### PR TITLE
M2Studio UX - Format Var Name

### DIFF
--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -190,6 +190,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
             autoComplete="off"
             value={variable.name || ""}
             data-testid="variable-name"
+            maxLength={kMaxNameCharacters}
             onChange={onNameChange}
             onMouseDown={handleFieldFocus}
             onFocus={handleFieldFocus}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183570281

[#183570281]

This change completes the requirements for the story by ensuring that the variable name field on the card only allows up to 27 characters. (Note that the PT story specifies 30 characters, but the specs say 27.)

Other requested features already existed were or were completed in an earlier PR.