### PR TITLE
Color Variable Chips to Match Card

### DIFF
--- a/src/diagram/components/ui/variable-chip.scss
+++ b/src/diagram/components/ui/variable-chip.scss
@@ -1,10 +1,23 @@
-@use "../../../scss/vars.scss";
+@import "../../../scss/vars.scss";
+@import "../../../scss/mixins.scss";
 
 .variable-chip {
-  border: 1px solid black;
-  border-radius: 5px;
-  padding: 1px 3px;
-  margin: 0 1px;
+
+  &.blue { @include spread-map($theme-map-blue); }
+  &.gray { @include spread-map($theme-map-gray); }
+  &.green { @include spread-map($theme-map-green); }
+  &.light-gray { @include spread-map($theme-map-light-gray); }
+  &.red { @include spread-map($theme-map-red); }
+  &.yellow { @include spread-map($theme-map-yellow); }
+
+  background: theme-var($--theme-color-5);
+  border: 1px solid $default-fg-color;
+  border-radius: 3px;
+  color: $default-fg-color;
+  font-family: $default-font-family;
+  font-size: $default-font-size;
+  padding: 1px 2px;
+  margin: 0;
   user-select: none;
   white-space: nowrap;
 
@@ -20,12 +33,16 @@
     padding: 0 2px;
   }
 
+  .variable-unit {
+    padding: 0 2px;
+  }
+
   &.disabled {
     opacity: 35%;
   }
 
   &.selected {
-    outline: 2px solid vars.$select-blue;
+    outline: 2px solid $select-blue;
   }
 
   // So selection matches text selection in slate

--- a/src/diagram/components/ui/variable-chip.tsx
+++ b/src/diagram/components/ui/variable-chip.tsx
@@ -25,7 +25,7 @@ export const VariableChip = observer(({ className, nameOnly, onClick, selected, 
   const showEquals = showValue && name;
   const wrapUnit = !showValue;
 
-  const classes = classNames("variable-chip", className, { selected });
+  const classes = classNames("variable-chip", className, variable.color, { selected });
 
   return (
     <span className={classes} onClick={e => onClick?.(variable)} >

--- a/src/scss/vars.scss
+++ b/src/scss/vars.scss
@@ -61,7 +61,7 @@ $--theme-color-5: --theme-color-5;
 $--theme-color-6: --theme-color-6;
 $--theme-color-7: --theme-color-7;
 
-// QuantityNode Color Themes
+// Color Themes
 $theme-map-blue: (
   $--theme-color-1: $color-blue-1,
   $--theme-color-2: $color-blue-2,


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183915153

[#183915153]

These changes make variable chips' colors match the chips' associated variable cards. The colors should be applied in the text and drawing tiles, as well as the insert dialogs. There are also some other minor styling tweaks to match specs. 