### PR TITLE
Fix crash when variable card deleted via keyboard DELETE key

### DIFF
--- a/src/diagram/components/diagram.tsx
+++ b/src/diagram/components/diagram.tsx
@@ -86,14 +86,14 @@ export const _Diagram = ({ dqRoot, getDiagramExport, hideControls, hideNavigator
   };
 
   const onElementsRemove = (elementsToRemove: Elements) => {
-    for(const element of elementsToRemove) {
+    for (const element of elementsToRemove) {
       if (isEdge((element as any))) {
         const edge = element as Edge;
         const { source, target } = edge;
         const targetModel = dqRoot.getNodeFromVariableId(target);
         const sourceModel = dqRoot.getNodeFromVariableId(source);
         // sourceModel gets removed first when a node is selected to be deleted, otherwise, just remove the connection
-        sourceModel.tryVariable && targetModel.removeInput(sourceModel.variable);
+        sourceModel?.tryVariable && targetModel.removeInput(sourceModel.variable);
       } else {
         // If this is the selected node we need to remove it from the state too
         const nodeToRemove = dqRoot.getNodeFromVariableId(element.id);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183929844

[#183929844]

This change fixes an issue where deleting a source variable card by selecting it and pressing the DELETE key on your keyboard would cause a white screen crash. 