### PR TITLE
Format static value and unit fields

### DIFF
--- a/src/diagram/components/quantity-node.scss
+++ b/src/diagram/components/quantity-node.scss
@@ -209,9 +209,8 @@ $color-gray-dark: #3f3f3f;
       text-align: right;
       width: $input-half-width;
     }
-    &.static {
+    &:disabled {
       background-color: theme-var($--theme-color-7);
-      padding: 3px 6px;
       &:hover { outline: none; }
     }
     &.no-value { color: gray; }

--- a/src/diagram/components/quantity-node.test.tsx
+++ b/src/diagram/components/quantity-node.test.tsx
@@ -129,6 +129,12 @@ describe("Quantity Node", () => {
     render(<Diagram dqRoot={root} />);
     expect(screen.getByTestId("diagram")).toBeInTheDocument();
     expect(screen.getByTestId("variable-expression")).toBeInTheDocument();
+    const valueFields = screen.getAllByTestId("variable-value");
+    expect(valueFields.length).toEqual(3);
+    expect(valueFields[2]).toBeDisabled();
+    const unitFields = screen.getAllByTestId("variable-unit");
+    expect(unitFields.length).toEqual(3);
+    expect(unitFields[2]).toBeDisabled();
   });
   it("quantity node entries should have expression field when there is only one input", () => {
     const inputA = Variable.create({id: "inputA", value: 999, unit: "m"});

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -185,7 +185,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
             />
           </div>
         }
-        {hasExpression ? renderValueUnitInput({disabled: true}) : renderValueUnitInput({disabled: false})}
+        {renderValueUnitInput({disabled: hasExpression})}
         <div className={classNames("variable-info-row", "description-row", { expanded: showDescription })}>
           {showDescription && 
             <TextareaAutosize

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -141,19 +141,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     );
   };
 
-  // const renderValueUnitUnEditable = () => {
-  //   return (
-  //     <div className="variable-info-row value-unit-row">
-  //       <div className={classNames("variable-info value static", {"no-value": !shownValue, "invalid": variable.computedValueError})}>
-  //         {shownValue !== undefined ? variable.computedValueWithSignificantDigits : "value"}
-  //       </div>
-  //       <div className={classNames("variable-info unit static", {"no-value": shownUnit, "invalid": variable.computedUnitError})}>
-  //         {shownUnit || "unit"}
-  //       </div>
-  //     </div>
-  //   );
-  // };
-
   const nodeHeight = hasExpression ? "155px" : "120px";
   const nodeWidth = "220px";
   const targetNodeHandleStyle = {height: nodeHeight, width: nodeWidth, left: "1px", opacity: 0, borderRadius: 0};

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -103,22 +103,29 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     data.dqRoot.setSelectedNode(data.dqRoot.selectedNode);
   };
 
-  const renderValueUnitInput = () => {
+  const renderValueUnitInput = (params: {disabled: boolean}) => {
+    const { disabled } = params;
+    const staticValue = shownValue !== undefined
+                          ? variable.computedValueWithSignificantDigits
+                          : undefined;
+
     return (
       <div className="variable-info-row value-unit-row">
         <ExpandableInput
+          disabled={disabled}
           error={!!(variable.computedValueError)}
           inputType="number"
           lengthToExpand={kDefaultExpandLength}
           maxLength={kMaxNameCharacters}
           placeholder="value"
           title="value"
-          value={variable.value}
+          value={!disabled ? variable.value : staticValue}
           handleBlur={handleFieldBlur}
           handleFocus={handleFieldFocus}
           setRealValue={variable.setValue}
         />
         <ExpandableInput
+          disabled={disabled}
           error={!!(variable.computedUnitError)}
           inputType="text"
           lengthToExpand={kDefaultExpandLength}
@@ -134,18 +141,18 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     );
   };
 
-  const renderValueUnitUnEditable = () => {
-    return (
-      <div className="variable-info-row value-unit-row">
-        <div className={classNames("variable-info value static", {"no-value": !shownValue, "invalid": variable.computedValueError})}>
-          {shownValue !== undefined ? variable.computedValueWithSignificantDigits : "value"}
-        </div>
-        <div className={classNames("variable-info unit static", {"no-value": shownUnit, "invalid": variable.computedUnitError})}>
-          {shownUnit || "unit"}
-        </div>
-      </div>
-    );
-  };
+  // const renderValueUnitUnEditable = () => {
+  //   return (
+  //     <div className="variable-info-row value-unit-row">
+  //       <div className={classNames("variable-info value static", {"no-value": !shownValue, "invalid": variable.computedValueError})}>
+  //         {shownValue !== undefined ? variable.computedValueWithSignificantDigits : "value"}
+  //       </div>
+  //       <div className={classNames("variable-info unit static", {"no-value": shownUnit, "invalid": variable.computedUnitError})}>
+  //         {shownUnit || "unit"}
+  //       </div>
+  //     </div>
+  //   );
+  // };
 
   const nodeHeight = hasExpression ? "155px" : "120px";
   const nodeWidth = "220px";
@@ -191,7 +198,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
             />
           </div>
         }
-        {hasExpression ? renderValueUnitUnEditable() : renderValueUnitInput()}
+        {hasExpression ? renderValueUnitInput({disabled: true}) : renderValueUnitInput({disabled: false})}
         <div className={classNames("variable-info-row", "description-row", { expanded: showDescription })}>
           {showDescription && 
             <TextareaAutosize

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -26,7 +26,7 @@ export const ExpandableInput = ({
   error, disabled, inputType, lengthToExpand, maxLength, placeholder, title, value, handleBlur,
   handleChange, handleFocus, handleKeyDown, setRealValue
 }: IProps) => {
-  const [hasLongValue, setHasLongValue] = useState(!!(value && value.toString().length >= lengthToExpand));
+  const [hasLongValue, setHasLongValue] = useState(value && value.toString().length >= lengthToExpand);
   const [showFullValue, setShowFullValue] = useState(hasLongValue);
 
   const handlToggleFullValue = () => {
@@ -34,7 +34,7 @@ export const ExpandableInput = ({
   };
 
   const onChange = (evt: ChangeEvent<HTMLTextAreaElement>) => {
-    const isLongValue = !!(evt.target.value && evt.target.value.length >= lengthToExpand);
+    const isLongValue = evt.target.value && evt.target.value.length >= lengthToExpand;
     setHasLongValue(isLongValue);
     setShowFullValue(isLongValue);
     if (handleChange) {
@@ -95,7 +95,7 @@ export const ExpandableInput = ({
 
   useEffect(() => {
     if (disabled && value) {
-      setHasLongValue(!!(value.toString().length >= lengthToExpand));
+      setHasLongValue(value.toString().length >= lengthToExpand);
     }
   }, [disabled, lengthToExpand, value]);
 

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -26,7 +26,12 @@ export const ExpandableInput = ({
   error, disabled, inputType, lengthToExpand, maxLength, placeholder, title, value, handleBlur,
   handleChange, handleFocus, handleKeyDown, setRealValue
 }: IProps) => {
-  const [hasLongValue, setHasLongValue] = useState(value && value.toString().length >= lengthToExpand);
+
+  const isLongValue = (val: number | string | undefined, length: number) => {
+    return val && val.toString().length >= length;
+  };
+
+  const [hasLongValue, setHasLongValue] = useState(isLongValue(value, lengthToExpand));
   const [showFullValue, setShowFullValue] = useState(hasLongValue);
 
   const handlToggleFullValue = () => {
@@ -34,9 +39,9 @@ export const ExpandableInput = ({
   };
 
   const onChange = (evt: ChangeEvent<HTMLTextAreaElement>) => {
-    const isLongValue = evt.target.value && evt.target.value.length >= lengthToExpand;
-    setHasLongValue(isLongValue);
-    setShowFullValue(isLongValue);
+    const isLong = isLongValue(evt.target.value, lengthToExpand);
+    setHasLongValue(isLong);
+    setShowFullValue(isLong);
     if (handleChange) {
       handleChange(evt);
     }
@@ -93,9 +98,12 @@ export const ExpandableInput = ({
     }
   };
 
+  // Ensure that hasLongValue is updated when the value changes in 
+  // disabled fields -- the onChange handler above does not get triggered
+  // by disabled fields.
   useEffect(() => {
     if (disabled && value) {
-      setHasLongValue(value.toString().length >= lengthToExpand);
+      setHasLongValue(isLongValue(value, lengthToExpand));
     }
   }, [disabled, lengthToExpand, value]);
 

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FocusEvent, MouseEvent, useState } from "react";
+import React, { ChangeEvent, FocusEvent, MouseEvent, useEffect, useState } from "react";
 import classNames from "classnames";
 import { NumberInput } from "./number-input";
 import { isValidNumber } from "../../utils/validate";
@@ -7,6 +7,7 @@ import { IconExpand } from "../icon-expand";
 import "./expandable-input.scss";
 
 interface IProps {
+  disabled?: boolean;
   error?: boolean;
   inputType: "text" | "number";
   lengthToExpand: number;
@@ -22,7 +23,7 @@ interface IProps {
 }
 
 export const ExpandableInput = ({
-  error, inputType, lengthToExpand, maxLength, placeholder, title, value, handleBlur,
+  error, disabled, inputType, lengthToExpand, maxLength, placeholder, title, value, handleBlur,
   handleChange, handleFocus, handleKeyDown, setRealValue
 }: IProps) => {
   const [hasLongValue, setHasLongValue] = useState(!!(value && value.toString().length >= lengthToExpand));
@@ -42,9 +43,16 @@ export const ExpandableInput = ({
   };
 
   const getInputElement = () => {
+    const inputClasses = classNames(
+      "variable-info variable-expression-area",
+      title,
+      {"invalid": !disabled && error}
+    );
+
     // NumberInput performs special handling of the entered value before 
-    // saving it. setRealValue is required for this.
-    if (inputType === "number" && setRealValue) {
+    // saving it which requires setRealValue. NumberInput should not be
+    // used for disabled value fields since their value may be a string.
+    if (!disabled && inputType === "number" && setRealValue) {
       return (
         <NumberInput
           className={inputClasses}
@@ -70,6 +78,7 @@ export const ExpandableInput = ({
           autoComplete="off"
           className={inputClasses}
           data-testid={`variable-${title}`}
+          disabled={disabled}
           maxLength={maxLength}
           onBlur={handleBlur}
           onChange={onChange}
@@ -84,15 +93,16 @@ export const ExpandableInput = ({
     }
   };
 
+  useEffect(() => {
+    if (disabled && value) {
+      setHasLongValue(!!(value.toString().length >= lengthToExpand));
+    }
+  }, [disabled, lengthToExpand, value]);
+
   const containerClasses = classNames(
     "expandable-input-container",
     {"expanded": hasLongValue && showFullValue},
     {"long": hasLongValue}
-  );
-  const inputClasses = classNames(
-    "variable-info variable-expression-area",
-    title,
-    {"invalid": error}
   );
 
   return (

--- a/src/diagram/components/ui/number-input.tsx
+++ b/src/diagram/components/ui/number-input.tsx
@@ -12,7 +12,10 @@ interface INumberInput {
   onValueChange?: (evt: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
-export const NumberInput = ({ className, dataTestId, isValid, otherProps, realValue, setRealValue, unsetSelectedNode, onValueChange }: INumberInput) => {
+export const NumberInput = ({
+  className, dataTestId, isValid, otherProps, realValue,
+  setRealValue, unsetSelectedNode, onValueChange
+}: INumberInput) => {
   const [value, setValue] = useState(realValue?.toString() || "");
   useEffect(() => {
     setValue(realValue?.toString() || "");


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183570351

[#183570351] 

[Previous work on this story](https://github.com/concord-consortium/quantity-playground/pull/42) left out required style changes to the static value and unit "fields" displayed below an expression field. The static value and unit weren't actually inputs but DIVs made to look like inputs.

These changes use disabled versions of the value and unit input fields to display the static values. Doing so allows re-use of the expand/collapse feature/styling recently added for the input fields.