### PR TITLE
Refactor method to prevent inadvertent dragging.

### DIFF
--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -89,18 +89,15 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
   };
 
   const handleFieldFocus = (evt: FocusEvent<HTMLInputElement|HTMLTextAreaElement>|MouseEvent<HTMLInputElement|HTMLTextAreaElement>) => {
-    // Stopping propagation allows the user to select text in the input field without 
-    // inadvertently dragging the card/node.
-    evt.stopPropagation();
-    data.dqRoot.setSelectedNode(data.node);
+    // Setting draggable to false allows the user to select text in the input field
+    // without inadvertently dragging the card/node.
+    data.node.setDraggable(false);
   };
 
   const handleFieldBlur = () => {
-    // This ensures that when the user clicks on a node other than the parent of the 
-    // field they're blurring, that the parent node is deselected. This would be 
-    // unnecessary if handleFieldFocus didn't stop propagation and explicitly set the
-    // selected node.
-    data.dqRoot.setSelectedNode(data.dqRoot.selectedNode);
+    // Ensure the parent node is made draggable after the user has finished editing
+    // the input field.
+    data.node.setDraggable(true);
   };
 
   const renderValueUnitInput = () => {

--- a/src/diagram/models/__snapshots__/dq-root.test.ts.snap
+++ b/src/diagram/models/__snapshots__/dq-root.test.ts.snap
@@ -8,24 +8,28 @@ Array [
         "flowTransform": undefined,
         "nodes": Object {
           "1": Object {
+            "draggable": true,
             "id": "1",
             "variable": "a",
             "x": 100,
             "y": 100,
           },
           "2": Object {
+            "draggable": true,
             "id": "2",
             "variable": "b",
             "x": 100,
             "y": 300,
           },
           "3": Object {
+            "draggable": true,
             "id": "3",
             "variable": "c",
             "x": 550,
             "y": 150,
           },
           "4": Object {
+            "draggable": true,
             "id": "4",
             "variable": "d",
             "x": 150,
@@ -34,12 +38,14 @@ Array [
         },
       },
       "node": Object {
+        "draggable": true,
         "id": "1",
         "variable": "a",
         "x": 100,
         "y": 100,
       },
     },
+    "draggable": true,
     "id": "a",
     "position": Object {
       "x": 100,
@@ -53,24 +59,28 @@ Array [
         "flowTransform": undefined,
         "nodes": Object {
           "1": Object {
+            "draggable": true,
             "id": "1",
             "variable": "a",
             "x": 100,
             "y": 100,
           },
           "2": Object {
+            "draggable": true,
             "id": "2",
             "variable": "b",
             "x": 100,
             "y": 300,
           },
           "3": Object {
+            "draggable": true,
             "id": "3",
             "variable": "c",
             "x": 550,
             "y": 150,
           },
           "4": Object {
+            "draggable": true,
             "id": "4",
             "variable": "d",
             "x": 150,
@@ -79,12 +89,14 @@ Array [
         },
       },
       "node": Object {
+        "draggable": true,
         "id": "2",
         "variable": "b",
         "x": 100,
         "y": 300,
       },
     },
+    "draggable": true,
     "id": "b",
     "position": Object {
       "x": 100,
@@ -98,24 +110,28 @@ Array [
         "flowTransform": undefined,
         "nodes": Object {
           "1": Object {
+            "draggable": true,
             "id": "1",
             "variable": "a",
             "x": 100,
             "y": 100,
           },
           "2": Object {
+            "draggable": true,
             "id": "2",
             "variable": "b",
             "x": 100,
             "y": 300,
           },
           "3": Object {
+            "draggable": true,
             "id": "3",
             "variable": "c",
             "x": 550,
             "y": 150,
           },
           "4": Object {
+            "draggable": true,
             "id": "4",
             "variable": "d",
             "x": 150,
@@ -124,12 +140,14 @@ Array [
         },
       },
       "node": Object {
+        "draggable": true,
         "id": "3",
         "variable": "c",
         "x": 550,
         "y": 150,
       },
     },
+    "draggable": true,
     "id": "c",
     "position": Object {
       "x": 550,
@@ -144,24 +162,28 @@ Array [
         "flowTransform": undefined,
         "nodes": Object {
           "1": Object {
+            "draggable": true,
             "id": "1",
             "variable": "a",
             "x": 100,
             "y": 100,
           },
           "2": Object {
+            "draggable": true,
             "id": "2",
             "variable": "b",
             "x": 100,
             "y": 300,
           },
           "3": Object {
+            "draggable": true,
             "id": "3",
             "variable": "c",
             "x": 550,
             "y": 150,
           },
           "4": Object {
+            "draggable": true,
             "id": "4",
             "variable": "d",
             "x": 150,
@@ -170,6 +192,7 @@ Array [
         },
       },
     },
+    "draggable": true,
     "id": "ea-targetc-a",
     "source": "a",
     "target": "c",
@@ -182,24 +205,28 @@ Array [
         "flowTransform": undefined,
         "nodes": Object {
           "1": Object {
+            "draggable": true,
             "id": "1",
             "variable": "a",
             "x": 100,
             "y": 100,
           },
           "2": Object {
+            "draggable": true,
             "id": "2",
             "variable": "b",
             "x": 100,
             "y": 300,
           },
           "3": Object {
+            "draggable": true,
             "id": "3",
             "variable": "c",
             "x": 550,
             "y": 150,
           },
           "4": Object {
+            "draggable": true,
             "id": "4",
             "variable": "d",
             "x": 150,
@@ -208,6 +235,7 @@ Array [
         },
       },
     },
+    "draggable": true,
     "id": "ed-targetc-a",
     "source": "d",
     "target": "c",
@@ -220,24 +248,28 @@ Array [
         "flowTransform": undefined,
         "nodes": Object {
           "1": Object {
+            "draggable": true,
             "id": "1",
             "variable": "a",
             "x": 100,
             "y": 100,
           },
           "2": Object {
+            "draggable": true,
             "id": "2",
             "variable": "b",
             "x": 100,
             "y": 300,
           },
           "3": Object {
+            "draggable": true,
             "id": "3",
             "variable": "c",
             "x": 550,
             "y": 150,
           },
           "4": Object {
+            "draggable": true,
             "id": "4",
             "variable": "d",
             "x": 150,
@@ -246,6 +278,7 @@ Array [
         },
       },
     },
+    "draggable": true,
     "id": "eb-targetc-a",
     "source": "b",
     "target": "c",
@@ -257,24 +290,28 @@ Array [
         "flowTransform": undefined,
         "nodes": Object {
           "1": Object {
+            "draggable": true,
             "id": "1",
             "variable": "a",
             "x": 100,
             "y": 100,
           },
           "2": Object {
+            "draggable": true,
             "id": "2",
             "variable": "b",
             "x": 100,
             "y": 300,
           },
           "3": Object {
+            "draggable": true,
             "id": "3",
             "variable": "c",
             "x": 550,
             "y": 150,
           },
           "4": Object {
+            "draggable": true,
             "id": "4",
             "variable": "d",
             "x": 150,
@@ -283,12 +320,14 @@ Array [
         },
       },
       "node": Object {
+        "draggable": true,
         "id": "4",
         "variable": "d",
         "x": 150,
         "y": 500,
       },
     },
+    "draggable": true,
     "id": "d",
     "position": Object {
       "x": 150,

--- a/src/diagram/models/dq-node.test.ts
+++ b/src/diagram/models/dq-node.test.ts
@@ -52,4 +52,18 @@ describe("DQNode", () => {
     expect(node.x).toBe(100);
     expect(node.y).toBe(50);
   });
+
+  it("has a draggable property that can be set to true or false", () => {
+    const variable = Variable.create({});
+    const node = DQNode.create({ variable: variable.id, x: 0, y: 0 });
+
+    // references have to be within the same tree so we need some container
+    const container = GenericContainer.create();
+    container.add(variable);
+    container.add(node);
+
+    expect(node.draggable).toBe(true);
+    node.setDraggable(false);
+    expect(node.draggable).toBe(false);
+  });
 });

--- a/src/diagram/models/dq-node.ts
+++ b/src/diagram/models/dq-node.ts
@@ -9,6 +9,7 @@ export const kDefaultNodeHeight = 98;
 export const DQNode = types.model("DQNode", {
   id: types.optional(types.identifier, () => nanoid(16)),
   variable: types.reference(Variable),
+  draggable: types.optional(types.boolean, true),
 
   // The x and y values are required when initializing the react flow
   // component. However the react flow component ignores them after this.
@@ -41,6 +42,7 @@ export const DQNode = types.model("DQNode", {
       type: "quantityNode",
       data: { node: self, dqRoot },
       position: { x: self.x, y: self.y },
+      draggable: self.draggable,
     });
 
     const variable = self.tryVariable;
@@ -55,6 +57,7 @@ export const DQNode = types.model("DQNode", {
             arrowHeadType: ArrowHeadType.ArrowClosed,
             type: "floatingEdge",
             data: { dqRoot },
+            draggable: self.draggable,
           });
         }
       });
@@ -71,7 +74,9 @@ export const DQNode = types.model("DQNode", {
     self.x = x;
     self.y = y;
   },
-
+  setDraggable(draggable: boolean) {
+    self.draggable = draggable;
+  },
   addInput(newInput: Instance<IAnyComplexType> | undefined) {
     self.tryVariable?.addInput((newInput as any)?.variable);
   },


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183644075

[#183644075]

Previously, we used `event.preventDefault()` when an input field was being brought into focus in order to prevent inadvertent dragging of the field's parent node when the user tried to select the field's text. Then we would use `setSelectedNode()` to set the field's parent node to be selected since `event.preventDefault()` prevented that from happening. This caused an issue where the selected node could not always reliably be unset when the field was blurred.

This approach uses React Flow's `draggable` node property, and doesn't require `event.preventDefault()`. So the selected state of nodes is properly set and unset.