### PR TITLE
Remove setting of selected node on field focus.

### DIFF
--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -92,15 +92,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     // Stopping propagation allows the user to select text in the input field without 
     // inadvertently dragging the card/node.
     evt.stopPropagation();
-    data.dqRoot.setSelectedNode(data.node);
-  };
-
-  const handleFieldBlur = () => {
-    // This ensures that when the user clicks on a node other than the parent of the 
-    // field they're blurring, that the parent node is deselected. This would be 
-    // unnecessary if handleFieldFocus didn't stop propagation and explicitly set the
-    // selected node.
-    data.dqRoot.setSelectedNode(data.dqRoot.selectedNode);
   };
 
   const renderValueUnitInput = (params: {disabled: boolean}) => {
@@ -120,7 +111,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
           placeholder="value"
           title="value"
           value={!disabled ? variable.value : staticValue}
-          handleBlur={handleFieldBlur}
           handleFocus={handleFieldFocus}
           setRealValue={variable.setValue}
         />
@@ -133,7 +123,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
           placeholder="unit"
           title="unit"
           value={shownUnit || ""}
-          handleBlur={handleFieldBlur}
           handleChange={onUnitChange}
           handleFocus={handleFieldFocus}
         />
@@ -166,7 +155,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
             onChange={onNameChange}
             onMouseDown={handleFieldFocus}
             onFocus={handleFieldFocus}
-            onBlur={handleFieldBlur}
           />
         </div>
         {hasExpression &&
@@ -178,7 +166,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
               placeholder="expression"
               title="expression"
               value={variable.expression || ""}
-              handleBlur={handleFieldBlur}
               handleChange={onExpressionChange}
               handleFocus={handleFieldFocus}
               handleKeyDown={handleExpressionKeyDown}
@@ -199,7 +186,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
               data-testid={"variable-description"}
               onMouseDown={handleFieldFocus}
               onFocus={handleFieldFocus}
-              onBlur={handleFieldBlur}
             />
           }
           <button className="variable-description-toggle" onClick={handleShowDescription} data-testid="variable-description-toggle-button">

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -15,7 +15,6 @@ interface IProps {
   placeholder?: string;
   title: string;
   value?: string | number;
-  handleBlur?: () => void;
   handleChange?: (evt: ChangeEvent<HTMLTextAreaElement>) => void;
   handleFocus?: (evt: FocusEvent<HTMLInputElement|HTMLTextAreaElement>|MouseEvent<HTMLInputElement|HTMLTextAreaElement>) => void;
   handleKeyDown?: (evt: React.KeyboardEvent) => void;
@@ -23,7 +22,7 @@ interface IProps {
 }
 
 export const ExpandableInput = ({
-  error, disabled, inputType, lengthToExpand, maxLength, placeholder, title, value, handleBlur,
+  error, disabled, inputType, lengthToExpand, maxLength, placeholder, title, value,
   handleChange, handleFocus, handleKeyDown, setRealValue
 }: IProps) => {
 
@@ -65,7 +64,6 @@ export const ExpandableInput = ({
           isValid={isValidNumber}
           realValue={value ? +value : undefined}
           setRealValue={setRealValue}
-          unsetSelectedNode={handleBlur}
           onValueChange={onChange}
           otherProps={{
             placeholder: "value",
@@ -85,7 +83,6 @@ export const ExpandableInput = ({
           data-testid={`variable-${title}`}
           disabled={disabled}
           maxLength={maxLength}
-          onBlur={handleBlur}
           onChange={onChange}
           onFocus={handleFocus}
           onKeyDown={handleKeyDown}

--- a/src/diagram/components/ui/number-input.tsx
+++ b/src/diagram/components/ui/number-input.tsx
@@ -8,13 +8,12 @@ interface INumberInput {
   otherProps?: Record<string, any>;
   realValue?: number;
   setRealValue: (value: number | undefined) => void;
-  unsetSelectedNode?: () => void;
   onValueChange?: (evt: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 export const NumberInput = ({
   className, dataTestId, isValid, otherProps, realValue,
-  setRealValue, unsetSelectedNode, onValueChange
+  setRealValue, onValueChange
 }: INumberInput) => {
   const [value, setValue] = useState(realValue?.toString() || "");
   useEffect(() => {
@@ -31,9 +30,6 @@ export const NumberInput = ({
       setRealValue(undefined);
     } else {
       setRealValue(+value);
-    }
-    if (unsetSelectedNode) {
-      unsetSelectedNode();
     }
   };
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183644075

[#183644075]

These changes undo the explicit setting of a card to be selected when a field on that card is brought into focus. That explicit setting was added as part of [this previous PR](https://github.com/concord-consortium/quantity-playground/pull/39), but wasn't called for in the spec and causes issues with deselection for which there doesn't seem to be a simple solution.