### PR TITLE
Fix crash when variable deleted by keyboard DELETE

### DIFF
--- a/src/diagram/components/diagram.tsx
+++ b/src/diagram/components/diagram.tsx
@@ -93,7 +93,7 @@ export const _Diagram = ({ dqRoot, getDiagramExport, hideControls, hideNavigator
         const targetModel = dqRoot.getNodeFromVariableId(target);
         const sourceModel = dqRoot.getNodeFromVariableId(source);
         // sourceModel gets removed first when a node is selected to be deleted, otherwise, just remove the connection
-        sourceModel?.tryVariable && targetModel.removeInput(sourceModel.variable);
+        sourceModel?.tryVariable && targetModel?.removeInput(sourceModel.variable);
       } else {
         // If this is the selected node we need to remove it from the state too
         const nodeToRemove = dqRoot.getNodeFromVariableId(element.id);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183929844

[#183929844]

Similar to [this fix for deleting a source card](https://github.com/concord-consortium/quantity-playground/pull/45), this will fix an issue where deleting a target/expression card by selecting it and pressing the DELETE key on your keyboard would cause a white screen crash.