### PR TITLE
feat: value not NaN should be default placeholder (PT-184196595)

### DIFF
--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -76,8 +76,8 @@ export const ExpandableInput = ({
         />
       );
     } else {
-      // Don't output NaN as a computed value.
-      const displayValue = value === "NaN" && inputType === "number" && disabled ? "" : value;
+      // Don't output NaN or Infinity as a computed value.
+      const displayValue = !isFinite(value as number) && inputType === "number" && disabled ? "" : value;
       return (
         <textarea
           autoComplete="off"

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -77,7 +77,7 @@ export const ExpandableInput = ({
       );
     } else {
       // Don't output NaN or Infinity as a computed value.
-      const displayValue = !isFinite(Number(value)) && inputType === "number" && disabled ? "" : value;
+      const displayValue = !isFinite(Number(value)) && inputType === "number" ? "" : value;
       return (
         <textarea
           autoComplete="off"

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -77,7 +77,7 @@ export const ExpandableInput = ({
       );
     } else {
       // Don't output NaN or Infinity as a computed value.
-      const displayValue = !isFinite(value as number) && inputType === "number" && disabled ? "" : value;
+      const displayValue = !isFinite(Number(value)) && inputType === "number" && disabled ? "" : value;
       return (
         <textarea
           autoComplete="off"

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -30,7 +30,14 @@ export const ExpandableInput = ({
     return val && val.toString().length >= length;
   };
 
-  const isValidValue = !(value === "NaN" && disabled);
+  const isValidValue = () => {
+    // Don't output NaN as a computed value.
+    if (value === "NaN" && placeholder === "value" && disabled) {
+      return false;
+    }
+    return true;
+  };
+
   const [hasLongValue, setHasLongValue] = useState(isLongValue(value, lengthToExpand));
   const [showFullValue, setShowFullValue] = useState(hasLongValue);
 
@@ -90,7 +97,7 @@ export const ExpandableInput = ({
           onMouseDown={handleFocus}
           placeholder={placeholder}
           spellCheck="false"
-          value={isValidValue ? value : ""}
+          value={isValidValue() ? value : ""}
         />
       );
     }

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -30,6 +30,7 @@ export const ExpandableInput = ({
     return val && val.toString().length >= length;
   };
 
+  const isValidValue = !(value === "NaN" && disabled);
   const [hasLongValue, setHasLongValue] = useState(isLongValue(value, lengthToExpand));
   const [showFullValue, setShowFullValue] = useState(hasLongValue);
 
@@ -89,7 +90,7 @@ export const ExpandableInput = ({
           onMouseDown={handleFocus}
           placeholder={placeholder}
           spellCheck="false"
-          value={value}
+          value={isValidValue ? value : ""}
         />
       );
     }

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -30,14 +30,6 @@ export const ExpandableInput = ({
     return val && val.toString().length >= length;
   };
 
-  const isValidValue = () => {
-    // Don't output NaN as a computed value.
-    if (value === "NaN" && placeholder === "value" && disabled) {
-      return false;
-    }
-    return true;
-  };
-
   const [hasLongValue, setHasLongValue] = useState(isLongValue(value, lengthToExpand));
   const [showFullValue, setShowFullValue] = useState(hasLongValue);
 
@@ -84,6 +76,8 @@ export const ExpandableInput = ({
         />
       );
     } else {
+      // Don't output NaN as a computed value.
+      const displayValue = value === "NaN" && inputType === "number" && disabled ? "" : value;
       return (
         <textarea
           autoComplete="off"
@@ -97,7 +91,7 @@ export const ExpandableInput = ({
           onMouseDown={handleFocus}
           placeholder={placeholder}
           spellCheck="false"
-          value={isValidValue() ? value : ""}
+          value={displayValue}
         />
       );
     }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184196595

These changes prevent `NaN` from appearing in the value field of an output card since students may not be familiar with the term. Instead, the placeholder value ("value") will be shown. It seemed best to me to have the `ExpandableInput` component check for and not output a `NaN` value. That allows the output field's existing placeholder ("value") to show.

One thing I'm not 100% sure about is the `isValidValue` function. It seems kind of like overkill to have a function since there's just one set of circumstances for which we don't want to output a particular value, but I think it helps make things a little easier to understand. And maybe it'd be good to have in case it turns out there are other values we don't want to display?