### PR TITLE
feat: add spellcheck=false to fields in edit variable dialog (PT-183914399)

### DIFF
--- a/src/diagram/components/dialog/edit-variable-dialog.tsx
+++ b/src/diagram/components/dialog/edit-variable-dialog.tsx
@@ -36,6 +36,7 @@ export const EditVariableDialogContent = observer(({ variable }: IEditVariableDi
         maxCharacters={kMaxNotesCharacters}
         rows={2}
         setValue={variable.setDescription}
+        spellCheck={true}
         value={variable.description || ""}
       />
       <TextRow inputId="evd-units" label="Units" value={variable.unit || ""} setValue={variable.setUnit} width={230} />

--- a/src/diagram/components/dialog/text-area-row.tsx
+++ b/src/diagram/components/dialog/text-area-row.tsx
@@ -13,12 +13,17 @@ interface ITextAreaRow {
   maxCharacters?: number;
   rows: number;
   setValue: (value: string) => void;
+  spellCheck?: boolean;
   value: string;
 }
-export const TextAreaRow = ({ cols, inputId, invalid, label, maxCharacters, rows, setValue, value }: ITextAreaRow) => {
+export const TextAreaRow = ({
+  cols, inputId, invalid, label, maxCharacters, rows, setValue, spellCheck,
+  value
+}: ITextAreaRow) => {
   const classes = classNames("dialog-input", { invalid }, "dialog-textarea");
   const content = (
     <textarea
+      autoComplete="off"
       className={classes}
       id={inputId}
       maxLength={maxCharacters}
@@ -26,6 +31,7 @@ export const TextAreaRow = ({ cols, inputId, invalid, label, maxCharacters, rows
       onChange={e => setValue(e.target.value)}
       cols={cols}
       rows={rows}
+      spellCheck={spellCheck}
     />
   );
   return <DialogRow content={content} inputId={inputId} label={label} />;

--- a/src/diagram/components/dialog/text-row.tsx
+++ b/src/diagram/components/dialog/text-row.tsx
@@ -17,6 +17,7 @@ export const TextRow = ({ inputId, invalid, label, maxCharacters, setValue, valu
   const classes = classNames("dialog-input", { invalid }, "dialog-text");
   const content = (
     <input
+      autoComplete="off"
       className={classes}
       id={inputId}
       type="text"
@@ -25,6 +26,7 @@ export const TextRow = ({ inputId, invalid, label, maxCharacters, setValue, valu
       onChange={e => setValue(e.target.value)}
       dir="auto"
       style={style}
+      spellCheck={false}
     />
   );
   return <DialogRow content={content} inputId={inputId} label={label} />;

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -176,6 +176,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
         <div className={classNames("variable-info-row", "description-row", { expanded: showDescription })}>
           {showDescription && 
             <TextareaAutosize
+              autoComplete="off"
               className="variable-description-area"
               value={variable.description || ""}
               onChange={onDescriptionChange}

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -67,8 +67,6 @@ export const ExpandableInput = ({
           onValueChange={onChange}
           otherProps={{
             placeholder: "value",
-            autoComplete: "off",
-            spellCheck: "false",
             maxLength,
             onMouseDown: handleFocus,
             onFocus: handleFocus,

--- a/src/diagram/components/ui/number-input.tsx
+++ b/src/diagram/components/ui/number-input.tsx
@@ -36,5 +36,16 @@ export const NumberInput = ({
   // We explicitly make "" valid here because it represents a variable with no specified value
   const invalid = value !== "" && !isValid(value);
 
-  return <textarea className={classNames(className, { invalid })} data-testid={dataTestId} value={value} onChange={onChange} onBlur={onBlur} {...otherProps} />;
+  return (
+    <textarea
+      className={classNames(className, { invalid })}
+      data-testid={dataTestId}
+      value={value}
+      onChange={onChange}
+      onBlur={onBlur}
+      {...otherProps}
+      autoComplete="off"
+      spellCheck={false}
+    />
+  );
 };


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183914399

These changes disable spellcheck and autocomplete (aka, autofill, autosuggest) for fields in the New/Edit Variable dialog. (An [earlier PR](https://github.com/concord-consortium/quantity-playground/tree/183914399-disable-spell-check) did the same for the fields in the variable cards.) Note that spellcheck should be enabled for the Notes/description field.