### PR TITLE
feat: Different Arrow for unused variables (PT-184037417)

### DIFF
--- a/src/diagram/components/connection-line.test.tsx
+++ b/src/diagram/components/connection-line.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ConnectionLine } from "./connection-line";
+
+const sourceX = 0;
+const sourceY = 0;
+const targetX = 100;
+const targetY = 100;
+const dValue = `M${sourceX},${sourceY} C ${sourceX} ${targetY} ${sourceX} ${targetY} ${targetX},${targetY}`;
+
+describe("ConnectionLine", () => {
+  it ("renders an SVG path to use as a connecting line between nodes", () => {
+    render(<ConnectionLine sourceX={sourceX} sourceY={sourceY} targetX={targetX} targetY={targetY} />);
+    expect(screen.getByTestId("connection-line")).toBeInTheDocument();
+    expect(screen.getByTestId("connection-line")).toHaveAttribute("d", dValue);
+  });
+});

--- a/src/diagram/components/connection-line.tsx
+++ b/src/diagram/components/connection-line.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface IProps {
+  sourceX: number;
+  sourceY: number;
+  targetX: number;
+  targetY: number;
+}
+
+export const ConnectionLine: React.FC<IProps> = ({ sourceX, sourceY, targetX, targetY }) =>  {
+  return (
+    <g className="react-flow__connection disconnected">
+      <path
+        className="react-flow__edge-path react-flow__edgeupdater disconnected"
+        data-testid="connection-line"
+        fill="none"
+        stroke="#0081ff"
+        strokeWidth={2}
+        d={`M${sourceX},${sourceY} C ${sourceX} ${targetY} ${sourceX} ${targetY} ${targetX},${targetY}`}
+      />
+    </g>
+  );
+};

--- a/src/diagram/components/connection-line.tsx
+++ b/src/diagram/components/connection-line.tsx
@@ -9,9 +9,9 @@ interface IProps {
 
 export const ConnectionLine: React.FC<IProps> = ({ sourceX, sourceY, targetX, targetY }) =>  {
   return (
-    <g className="react-flow__connection disconnected">
+    <g className="react-flow__connection">
       <path
-        className="react-flow__edge-path react-flow__edgeupdater disconnected"
+        className="react-flow__connection-path"
         data-testid="connection-line"
         fill="none"
         stroke="#0081ff"

--- a/src/diagram/components/diagram.scss
+++ b/src/diagram/components/diagram.scss
@@ -5,35 +5,41 @@
 //   border-radius: 5px;
 // }
 
-// The stroke-width affects the marker
-// Color settings on the path do not affect the marker
-// Because colors don't affect this means the arrows do not
-// change colors when the path is selected
-// A general SVG workground for this is described here:
-// https://stackoverflow.com/questions/16664584/changing-an-svg-markers-color-css/50189360
-//
-// The marker end IDs used here are defined in the diagram component.
-//
-.react-flow__edge-path {
-  marker-end: url("#custom-arrow");
-  stroke: $color-light-gray-2;
-  stroke-dasharray: 0, 10;
-  stroke-linecap: round;
-  stroke-width: 3;
+// While some stroke settings affect the path markers (arrowheads), stroke color
+// settings do not. To support different colored arrowheads, we define custom SVG
+// markers in the Diagram component and set marker-end properties to the custom 
+// markers' IDs in the style rules below. 
+.react-flow__edge {
+  &.used-in-expression {
+    .react-flow__edge-path {
+      marker-end: url("#custom-arrow__selected-or-used");
+      stroke: $color-gray-1;
+      stroke-dasharray: 0;
+      stroke-width: 2;
+    }
+  }
 
-  &.disconnected {
-    marker-end: url("#custom-arrow__drag");
-    stroke: $select-blue;
+  &.selected {
+    .react-flow__edge-path {
+      marker-end: url("#custom-arrow__selected-or-used");
+    }
+  }
+
+  .react-flow__edge-path {
+    marker-end: url("#custom-arrow");
+    stroke: $color-light-gray-2;
+    stroke-dasharray: 0, 10;
+    stroke-linecap: round;
+    stroke-width: 3;
   }
 }
 
-.source-used-in-target-expression {
-  .react-flow__edge-path {
-    marker-end: url("#custom-arrow__in-expression");
-    stroke: $color-gray-1;
-    stroke-dasharray: 0;
-    stroke-width: 2;
-  }
+.react-flow__connection-path {
+  marker-end: url("#custom-arrow__dragging");
+  stroke: $select-blue;
+  stroke-dasharray: 0, 10;
+  stroke-linecap: round;
+  stroke-width: 3;
 }
 
 .nested-set-node {

--- a/src/diagram/components/diagram.scss
+++ b/src/diagram/components/diagram.scss
@@ -1,3 +1,5 @@
+@import "../../scss/vars.scss";
+
 // .react-flow__node.selected {
 //   border: 1px solid black;
 //   border-radius: 5px;
@@ -9,8 +11,29 @@
 // change colors when the path is selected
 // A general SVG workground for this is described here:
 // https://stackoverflow.com/questions/16664584/changing-an-svg-markers-color-css/50189360
+//
+// The marker end IDs used here are defined in the diagram component.
+//
 .react-flow__edge-path {
-  stroke-width: 2.5;
+  marker-end: url("#custom-arrow");
+  stroke: $color-light-gray-2;
+  stroke-dasharray: 0, 10;
+  stroke-linecap: round;
+  stroke-width: 3;
+
+  &.disconnected {
+    marker-end: url("#custom-arrow__drag");
+    stroke: $select-blue;
+  }
+}
+
+.source-used-in-target-expression {
+  .react-flow__edge-path {
+    marker-end: url("#custom-arrow__in-expression");
+    stroke: $color-gray-1;
+    stroke-dasharray: 0;
+    stroke-width: 2;
+  }
 }
 
 .nested-set-node {

--- a/src/diagram/components/diagram.tsx
+++ b/src/diagram/components/diagram.tsx
@@ -8,6 +8,8 @@ import { QuantityNode } from "./quantity-node";
 import { FloatingEdge } from "./floating-edge";
 import { ToolBar } from "./toolbar";
 import { DiagramHelper } from "../utils/diagram-helper";
+import { ConnectionLine } from "./connection-line";
+import { MarkerEnd } from "./marker-end";
 
 // We use the nocss version of RF so we can manually load
 // the CSS. This way we can override it.
@@ -188,7 +190,18 @@ export const _Diagram = ({ dqRoot, getDiagramExport, hideControls, hideNavigator
   return (
     <div className="diagram" ref={reactFlowWrapper} data-testid="diagram">
       <ReactFlowProvider>
+        <svg>
+          <defs>
+            {/* These custom arrowheads are used to change the connecting line/edge arrowhead
+                color as needed. See default.scss for usage. If we upgrade to a newer version
+                of React Flow, there may be a cleaner way to change the arrow colors. */}
+            <MarkerEnd markerId="custom-arrow" markerColor="#949494" />
+            <MarkerEnd markerId="custom-arrow__drag" markerColor="#0081ff" />
+            <MarkerEnd markerId="custom-arrow__in-expression" markerColor="#5a5a5a" />
+          </defs>
+        </svg>
         <ReactFlow
+          connectionLineComponent={ConnectionLine}
           elements={dqRoot.reactFlowElements}
           defaultPosition={defaultPosition}
           defaultZoom={defaultZoom}

--- a/src/diagram/components/diagram.tsx
+++ b/src/diagram/components/diagram.tsx
@@ -196,8 +196,8 @@ export const _Diagram = ({ dqRoot, getDiagramExport, hideControls, hideNavigator
                 color as needed. See default.scss for usage. If we upgrade to a newer version
                 of React Flow, there may be a cleaner way to change the arrow colors. */}
             <MarkerEnd markerId="custom-arrow" markerColor="#949494" />
-            <MarkerEnd markerId="custom-arrow__drag" markerColor="#0081ff" />
-            <MarkerEnd markerId="custom-arrow__in-expression" markerColor="#5a5a5a" />
+            <MarkerEnd markerId="custom-arrow__selected-or-used" markerColor="#5a5a5a" />
+            <MarkerEnd markerId="custom-arrow__dragging" markerColor="#0081ff" />
           </defs>
         </svg>
         <ReactFlow

--- a/src/diagram/components/floating-edge.tsx
+++ b/src/diagram/components/floating-edge.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { getBezierPath, useStoreState } from "react-flow-renderer/nocss";
 import { getEdgeParams } from "../../utils/diagram/floating-edge-util";
-import classNames from "classnames";
 
 interface IProps {
   id: string;
@@ -13,8 +12,6 @@ export const FloatingEdge: React.FC<IProps> = ({ id, source, target }) =>  {
   const nodes = useStoreState((state) => state.nodes);
   const sourceNode = useMemo(() => nodes.find((n) => n.id === source), [source, nodes]);
   const targetNode = useMemo(() => nodes.find((n) => n.id === target), [target, nodes]);
-  const sourceVariableName = sourceNode?.data.node.variable?.name;
-  const isUsedInExpression = targetNode?.data.node.variable?.expression?.includes(sourceVariableName) || false;
 
   if (!source || !target) {
     return null;
@@ -32,13 +29,9 @@ export const FloatingEdge: React.FC<IProps> = ({ id, source, target }) =>  {
     targetY,
   });
 
-  const edgeClasses = classNames(
-    "react-flow__connection",
-    { "source-used-in-target-expression": isUsedInExpression }
-  );
   // used the react-flow__edgeupdater class because it has some react-flow-renderer event handler that allows the edge to be deleted
   return (
-    <g className={edgeClasses}>
+    <g className="react-flow__connection">
       <path id={id} className="react-flow__edge-path react-flow__edgeupdater" d={d}/>
     </g>
   );

--- a/src/diagram/components/floating-edge.tsx
+++ b/src/diagram/components/floating-edge.tsx
@@ -1,33 +1,45 @@
 import React, { useMemo } from "react";
 import { getBezierPath, useStoreState } from "react-flow-renderer/nocss";
 import { getEdgeParams } from "../../utils/diagram/floating-edge-util";
+import classNames from "classnames";
 
 interface IProps {
   id: string;
   source: string;
   target: string;
 }
-export const FloatingEdge: React.FC<IProps>  = ({ id, source, target }) =>  {
+
+export const FloatingEdge: React.FC<IProps> = ({ id, source, target }) =>  {
   const nodes = useStoreState((state) => state.nodes);
   const sourceNode = useMemo(() => nodes.find((n) => n.id === source), [source, nodes]);
   const targetNode = useMemo(() => nodes.find((n) => n.id === target), [target, nodes]);
+  const sourceVariableName = sourceNode?.data.node.variable?.name;
+  const isUsedInExpression = targetNode?.data.node.variable?.expression?.includes(sourceVariableName) || false;
 
   if (!source || !target) {
     return null;
   }
   const { sx, sy, tx, ty, sourcePos, targetPos } = getEdgeParams(sourceNode, targetNode);
+  const arrowHeadOffset = 3;
+  const targetX = sx < tx ? tx - arrowHeadOffset : tx + arrowHeadOffset;
+  const targetY = sy < ty ? ty - arrowHeadOffset : ty + arrowHeadOffset;
   const d = getBezierPath({
     sourceX: sx,
     sourceY: sy,
     sourcePosition: sourcePos,
     targetPosition: targetPos,
-    targetX: tx,
-    targetY: ty,
+    targetX,
+    targetY,
   });
+
+  const edgeClasses = classNames(
+    "react-flow__connection",
+    { "source-used-in-target-expression": isUsedInExpression }
+  );
   // used the react-flow__edgeupdater class because it has some react-flow-renderer event handler that allows the edge to be deleted
   return (
-    <g className="react-flow__connection">
-      <path id={id} className="react-flow__edge-path react-flow__edgeupdater" d={d} markerEnd="url(#react-flow__arrowclosed)"/>
+    <g className={edgeClasses}>
+      <path id={id} className="react-flow__edge-path react-flow__edgeupdater" d={d}/>
     </g>
   );
 };

--- a/src/diagram/components/marker-end.test.tsx
+++ b/src/diagram/components/marker-end.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MarkerEnd } from "./marker-end";
+
+const markerId = "test-id";
+const markerColor = "#ff0000";
+
+describe("MarkerEnd", () => {
+  it ("renders an SVG marker to use on connecting line between nodes", () => {
+    render(<MarkerEnd markerId={markerId} markerColor={markerColor} />);
+    expect(screen.getByTestId("marker-end")).toBeInTheDocument();
+    expect(screen.getByTestId("marker-end")).toHaveAttribute("id", markerId);
+    expect(screen.getByTestId("marker-end-polygon")).toBeInTheDocument();
+    expect(screen.getByTestId("marker-end-polygon")).toHaveAttribute("fill", markerColor);
+  });
+});

--- a/src/diagram/components/marker-end.tsx
+++ b/src/diagram/components/marker-end.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface IMarkerProps {
+  markerColor: string;
+  markerId: string;
+}
+
+export const MarkerEnd: React.FC<IMarkerProps> = ({ markerId, markerColor }) => {
+  return (
+    <marker
+      className="react-flow__arrowhead"
+      data-testid="marker-end"
+      id={markerId}
+      markerHeight="25"
+      markerWidth="25"
+      markerUnits="userSpaceOnUse"
+      orient="auto"
+      refX="0"
+      refY="0"
+      viewBox="-10 -10 20 20"
+    >
+      <polygon
+        data-testid="marker-end-polygon"
+        fill={markerColor}
+        points="-8,-4 0,0 -8,4 -8,-4"
+        stroke={markerColor}
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+        strokeWidth="2.5"
+      />
+    </marker>
+  );
+};

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -11,9 +11,9 @@ import { kMaxNameCharacters, kMaxNotesCharacters, processName } from "../utils/v
 import { ExpandableInput } from "./ui/expandable-input";
 import { IconColorMenu } from "./icon-color-menu";
 import { IconExpand } from "./icon-expand";
+import { ErrorMessage } from "./error-message";
 
 import "./quantity-node.scss";
-import { ErrorMessage } from "./error-message";
 
 interface IProps {
   data: {node: DQNodeType, dqRoot: DQRootType};
@@ -69,6 +69,12 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
       variable.setExpression(undefined);
     } else {
       variable.setExpression(evt.target.value);
+    }
+    const inputs = variable.inputs as any;
+    // remove and reconnect input nodes
+    for (const input of inputs) {
+      variable.removeInput(input);
+      variable.addInput(input);
     }
   };
 

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -12,7 +12,6 @@ import { ExpandableInput } from "./ui/expandable-input";
 import { IconColorMenu } from "./icon-color-menu";
 import { IconExpand } from "./icon-expand";
 import { ErrorMessage } from "./error-message";
-import { VariableType } from "../models/variable";
 
 import "./quantity-node.scss";
 
@@ -70,15 +69,6 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
       variable.setExpression(undefined);
     } else {
       variable.setExpression(evt.target.value);
-    }
-    // The appearance of the edges coming from input nodes changes based on
-    // whether they are used in the expression. To ensure their appearance
-    // is updated when the expression changes, remove and re-connect the
-    // inputs which forces the edges to re-render.
-    const inputs = variable.inputs as unknown as VariableType[];
-    for (const input of inputs) {
-      variable.removeInput(input);
-      variable.addInput(input);
     }
   };
 

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -12,6 +12,7 @@ import { ExpandableInput } from "./ui/expandable-input";
 import { IconColorMenu } from "./icon-color-menu";
 import { IconExpand } from "./icon-expand";
 import { ErrorMessage } from "./error-message";
+import { VariableType } from "../models/variable";
 
 import "./quantity-node.scss";
 
@@ -70,8 +71,11 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     } else {
       variable.setExpression(evt.target.value);
     }
-    const inputs = variable.inputs as any;
-    // remove and reconnect input nodes
+    // The appearance of the edges coming from input nodes changes based on
+    // whether they are used in the expression. To ensure their appearance
+    // is updated when the expression changes, remove and re-connect the
+    // inputs which forces the edges to re-render.
+    const inputs = variable.inputs as unknown as VariableType[];
     for (const input of inputs) {
       variable.removeInput(input);
       variable.addInput(input);

--- a/src/diagram/models/__snapshots__/dq-root.test.ts.snap
+++ b/src/diagram/models/__snapshots__/dq-root.test.ts.snap
@@ -139,6 +139,7 @@ Array [
   },
   Object {
     "arrowHeadType": "arrowclosed",
+    "className": "",
     "data": Object {
       "dqRoot": Object {
         "flowTransform": undefined,
@@ -177,6 +178,7 @@ Array [
   },
   Object {
     "arrowHeadType": "arrowclosed",
+    "className": "",
     "data": Object {
       "dqRoot": Object {
         "flowTransform": undefined,
@@ -215,6 +217,7 @@ Array [
   },
   Object {
     "arrowHeadType": "arrowclosed",
+    "className": "",
     "data": Object {
       "dqRoot": Object {
         "flowTransform": undefined,

--- a/src/diagram/models/dq-node.ts
+++ b/src/diagram/models/dq-node.ts
@@ -46,8 +46,10 @@ export const DQNode = types.model("DQNode", {
     const variable = self.tryVariable;
     if (variable) {
       const inputs = self.variable.inputs as unknown as VariableType[] | undefined;
+      const usedInputs = self.variable.inputsInExpression;
       inputs?.forEach((input) => {
         if (input) {
+          const usedInExpression = input.name && usedInputs?.includes(input.name);
           elements.push({
             id: `e${input.id}-target${id}-a`,
             source: input.id,
@@ -55,6 +57,7 @@ export const DQNode = types.model("DQNode", {
             arrowHeadType: ArrowHeadType.ArrowClosed,
             type: "floatingEdge",
             data: { dqRoot },
+            className: usedInExpression ? "used-in-expression" : "",
           });
         }
       });

--- a/src/diagram/models/mathjs-utils.test.ts
+++ b/src/diagram/models/mathjs-utils.test.ts
@@ -34,22 +34,12 @@ describe("mathjs-utils", () => {
     });
   });
   describe("replaceInputNames", () => {
-    it("replaces backtick variables", () => {
-      const result = replaceInputNames("`var`", ["var"]);
-      expect(result).toBe("input_0");
-    });
-
-    it("replaces backtick variables with multiple inputs", () => {
-      const result = replaceInputNames("`var`", ["foo", "var"]);
-      expect(result).toBe("input_1");
-    });
-
-    it("replaces names without backticks", () => {
+    it("replaces names used in expression", () => {
       const result = replaceInputNames("var", ["var"]);
       expect(result).toBe("input_0");
     });
 
-    it("replaces names without backticks and mutltiple inputs", () => {
+    it("replaces names used in expression when there are multiple inputs", () => {
       const result = replaceInputNames("var", ["foo", "var"]);
       expect(result).toBe("input_1");
     });
@@ -65,19 +55,6 @@ describe("mathjs-utils", () => {
       expect(replaceInputNames("var 2 * var",inputs)).toBe("input_1 2 * input_1");
       expect(replaceInputNames("var-foo",inputs)).toBe("input_1 - input_0");
       expect(replaceInputNames("-var",inputs)).toBe("-input_1");
-    });
-
-    it("replaces names with backticks", () => {
-      const inputs = ["foo b", "var a"];
-
-      expect(replaceInputNames("`var a`/1",inputs)).toBe("input_1 / 1");
-      expect(replaceInputNames("2`var a`",inputs)).toBe("2 input_1");
-      expect(replaceInputNames("`var a`^2",inputs)).toBe("input_1 ^ 2");
-      expect(replaceInputNames("varA * `var a`",inputs)).toBe("varA * input_1");
-      expect(replaceInputNames("var2 * `var a`",inputs)).toBe("var2 * input_1");
-      expect(replaceInputNames("`var a` 2 * `var a`",inputs)).toBe("input_1 2 * input_1");
-      expect(replaceInputNames("`var a`-`foo b`",inputs)).toBe("input_1 - input_0");
-      expect(replaceInputNames("-`var a`",inputs)).toBe("-input_1");
     });
   });
 });

--- a/src/diagram/models/mathjs-utils.ts
+++ b/src/diagram/models/mathjs-utils.ts
@@ -29,19 +29,8 @@ export const getMathUnit = (value: number, unitString: string): math.Unit | unde
   }
 };
 
-// 1. use string replace of the inputNames with backticks
-// 2. then find all symbols and look for matches in those symbols
-// 3. if they match replace them 
 export const replaceInputNames = (expression: string, inputNames: (string | undefined)[]) => {
-  let localExpression = expression;
-
-  inputNames.forEach((name, index) => {
-    if (!name) {
-      return;
-    }
-    // A RegExp is used so all matches are replaced not just the first one
-    localExpression = localExpression.replace(RegExp("`" + name + "`", "g"), `input_${index}`);
-  });
+  const localExpression = expression;
 
   try {
     const expressionNode = parse(localExpression);

--- a/src/diagram/models/mathjs-utils.ts
+++ b/src/diagram/models/mathjs-utils.ts
@@ -29,8 +29,9 @@ export const getMathUnit = (value: number, unitString: string): math.Unit | unde
   }
 };
 
-export const replaceInputNames = (expression: string, inputNames: (string | undefined)[]) => {
+export const parseExpression = (expression: string, inputNames: (string | undefined)[]) => {
   const localExpression = expression;
+  const inputsInExpression: string[] = [];
 
   try {
     const expressionNode = parse(localExpression);
@@ -39,12 +40,21 @@ export const replaceInputNames = (expression: string, inputNames: (string | unde
       inputNames.forEach((name, index) => {
         if (symbol.name === name) {
           symbol.name = `input_${index}`;
+          inputsInExpression.push(name);
         }
       });
     }
-    return expressionNode.toString();
+    return { expression: expressionNode.toString(), inputsInExpression };
   } catch (e) {
-    // if there is parse error just return the expression for now
-    return localExpression;
+    // if there is parse error, return the original expression for now
+    return { expression: localExpression, inputsInExpression };
   }
+};
+
+export const replaceInputNames = (expression: string, inputNames: (string | undefined)[]) => {
+  return parseExpression(expression, inputNames).expression;
+};
+
+export const getUsedInputs = (expression: string, inputNames: (string | undefined)[]) => {
+  return parseExpression(expression, inputNames).inputsInExpression;
 };

--- a/src/diagram/models/variable.ts
+++ b/src/diagram/models/variable.ts
@@ -126,8 +126,7 @@ export const Variable = types.model("Variable", {
       }
 
       // TODO: you can make an expression that only uses one input and the other
-      // input is connected but not used. In that case the unused input should
-      // should be skipped.
+      // input is connected but not used. In that case the unused input should be skipped.
       //
       // Currently if an unused input doesn't have a value, the output will show
       // NaN because of the validation below.

--- a/src/diagram/models/variable.ts
+++ b/src/diagram/models/variable.ts
@@ -1,7 +1,7 @@
 import { evaluate, isUnit } from "../custom-mathjs";
 import { IAnyComplexType, Instance, types } from "mobx-state-tree";
 import { nanoid } from "nanoid";
-import { getMathUnit, replaceInputNames } from "./mathjs-utils";
+import { getMathUnit, getUsedInputs, replaceInputNames } from "./mathjs-utils";
 import math from "mathjs";
 import { Colors, legacyColors } from "../utils/theme-utils";
 
@@ -71,6 +71,13 @@ export const Variable = types.model("Variable", {
       // Then view reverses this. This way it will update when the nodes
       // change.
       return replaceInputNames(self.expression, self.inputNames);
+    }
+  }
+}))
+.views(self => ({
+  get inputsInExpression() {
+    if (self.expression) {
+      return getUsedInputs(self.expression, self.inputNames);
     }
   }
 }))


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184037417

Adds multiple styles for connecting lines (aka edges) between nodes. The main purpose is to differentiate inputs used in a target node's expression from those that aren't used in the expression. The two kinds of edges are different in color and line type. See PT story and screenshot below for details.

Three custom SVG marker ends are now defined in the `Diagram` component which are then utilized in diagram.scss. The marker ends are essentially the same except in color.

There is also a new `ConnectionLine` component used to render edges when they are first created, before they are connected to a target node. Unconnected edges are differentiated from connected edges by their color (blue).

These changes could very possibly be simplified after we update to a new version of React Flow. (I attempted an update but ran into a problem that I couldn't solve in the allotted time.)

![image](https://user-images.githubusercontent.com/367459/216062155-8c9ba037-9788-47d6-964a-847f52b841a1.png)


