### PR TITLE
fix: Some calculated values not showing (PT-184373405)

### DIFF
--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -75,10 +75,10 @@ export const ExpandableInput = ({
       );
     } else {
       // Don't output NaN or Infinity as a computed value.
-      // Before checking for NaN or Infinity, make sure to remove any commas in a value
-      // that is a string. Otherwise, a string value like "1,000" will be considered NaN.
-      const possibleNumberValue = typeof value === "string" ? value.replace(/,/g, "") : value;
-      const displayValue = !isFinite(Number(possibleNumberValue)) && inputType === "number" ? "" : value;
+      // Note that parseFloat will convert a string value like "1,000" to the number 1000,
+      // Number("1,000") will return NaN.
+      const possibleNumberValue = value && typeof value === "string" ? parseFloat(value) : Number(value);
+      const displayValue = !isFinite(possibleNumberValue) && inputType === "number" ? "" : value;
       return (
         <textarea
           autoComplete="off"

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -75,7 +75,10 @@ export const ExpandableInput = ({
       );
     } else {
       // Don't output NaN or Infinity as a computed value.
-      const displayValue = !isFinite(Number(value)) && inputType === "number" ? "" : value;
+      // Before checking for NaN or Infinity, make sure to remove any commas in a value
+      // that is a string. Otherwise, a string value like "1,000" will be considered NaN.
+      const possibleNumberValue = typeof value === "string" ? value.replace(/,/g, "") : value;
+      const displayValue = !isFinite(Number(possibleNumberValue)) && inputType === "number" ? "" : value;
       return (
         <textarea
           autoComplete="off"

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -75,10 +75,10 @@ export const ExpandableInput = ({
       );
     } else {
       // Don't output NaN or Infinity as a computed value.
-      // Note that parseFloat will convert a string value like "1,000" to the number 1000,
-      // Number("1,000") will return NaN.
-      const possibleNumberValue = value && typeof value === "string" ? parseFloat(value) : Number(value);
-      const displayValue = !isFinite(possibleNumberValue) && inputType === "number" ? "" : value;
+      // Before checking for NaN or Infinity, make sure to remove any commas in a value
+      // that is a string. Otherwise, a string value like "1,000" will be considered NaN.
+      const possibleNumberValue = typeof value === "string" ? value.replace(/,/g, "") : value;
+      const displayValue = !isFinite(Number(possibleNumberValue)) && inputType === "number" ? "" : value;
       return (
         <textarea
           autoComplete="off"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184373405

[Recent work](https://github.com/concord-consortium/quantity-playground/pull/52) to prevent `NaN` being displayed for a computed value resulted in some computed values not being displayed. It seems the added `!isFinite(Number(value))` check doesn't work as planned for string values like "1,000,000". `Number("1,000,000")` will return `NaN`. However, `Number("1000000")` will return the number `1000000`.

This change would pass a version of `value` that has any commas stripped out to `Number` so it correctly converts string values like "1,000,000" to numbers when doing the check for `NaN`.