### PR TITLE
fix: Different arrow for unused variables. (PT-184037417)

### DIFF
--- a/src/diagram/models/mathjs-utils.test.ts
+++ b/src/diagram/models/mathjs-utils.test.ts
@@ -1,4 +1,4 @@
-import {getMathUnit, replaceInputNames} from "./mathjs-utils";
+import {getMathUnit, replaceInputNames, getUsedInputs} from "./mathjs-utils";
 
 describe("mathjs-utils", () => {
   describe("getMathUnit", () => {
@@ -55,6 +55,16 @@ describe("mathjs-utils", () => {
       expect(replaceInputNames("var 2 * var",inputs)).toBe("input_1 2 * input_1");
       expect(replaceInputNames("var-foo",inputs)).toBe("input_1 - input_0");
       expect(replaceInputNames("-var",inputs)).toBe("-input_1");
+    });
+  });
+  describe("getUsedInputs", () => {
+    it("returns the names of available input variables used in a valid expression", () => {
+      const result = getUsedInputs("var1+var2", ["var1", "var2", "var3"]);
+      expect(result).toStrictEqual(["var1", "var2"]);
+    });
+    it("returns the names of available input variables used in an invalid expression", () => {
+      const result = getUsedInputs("var1+var2+", ["var1", "var2", "var3"]);
+      expect(result).toStrictEqual(["var1", "var2"]);
     });
   });
 });

--- a/src/diagram/models/mathjs-utils.ts
+++ b/src/diagram/models/mathjs-utils.ts
@@ -49,7 +49,7 @@ export const parseExpression = (expression: string, inputNames: (string | undefi
     // If there is parse error, return the original expression for now
     // and use a regex to find the input names in the expression.
     inputNames.forEach((name) => {
-      const variableRegex = new RegExp(`(^|[÷,×,+,-,-,/,*])${name}[÷,×,+,-,-,/,*]`);
+      const variableRegex = new RegExp(`(^|[÷,×,+,-,-,/,*,),(])${name}([÷,×,+,-,-,/,*,(,)]|$)`);
       if (name && variableRegex.test(localExpression)) {
         inputsInExpression.push(name);
       }

--- a/src/diagram/models/mathjs-utils.ts
+++ b/src/diagram/models/mathjs-utils.ts
@@ -46,7 +46,14 @@ export const parseExpression = (expression: string, inputNames: (string | undefi
     }
     return { expression: expressionNode.toString(), inputsInExpression };
   } catch (e) {
-    // if there is parse error, return the original expression for now
+    // If there is parse error, return the original expression for now
+    // and use a regex to find the input names in the expression.
+    inputNames.forEach((name) => {
+      const variableRegex = new RegExp(`(^|[÷,×,+,-,-,/,*])${name}[÷,×,+,-,-,/,*]`);
+      if (name && variableRegex.test(localExpression)) {
+        inputsInExpression.push(name);
+      }
+    });
     return { expression: localExpression, inputsInExpression };
   }
 };

--- a/src/diagram/models/mathjs-utils.ts
+++ b/src/diagram/models/mathjs-utils.ts
@@ -46,10 +46,11 @@ export const parseExpression = (expression: string, inputNames: (string | undefi
     }
     return { expression: expressionNode.toString(), inputsInExpression };
   } catch (e) {
-    // If there is parse error, return the original expression for now
-    // and use a regex to find the input names in the expression.
+    // If there is parse error, return the original expression for now and
+    // use a regex to find the input names in the expression.
+    // Note there are slightly different subtract signs we need to handle.
     inputNames.forEach((name) => {
-      const variableRegex = new RegExp(`(^|[÷,×,+,-,-,/,*,),(])${name}([÷,×,+,-,-,/,*,(,)]|$)`);
+      const variableRegex = new RegExp(`(^|[÷,×,+,-,-,/,*,),(,^])${name}([÷,×,+,-,-,/,*,(,),^]|$)`);
       if (name && variableRegex.test(localExpression)) {
         inputsInExpression.push(name);
       }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184037417

[Recent changes](https://github.com/concord-consortium/quantity-playground/pull/54) to style input arrows based on whether they're used in an expression could result in a used input's arrow being styled as if it's _not_ used if an invalid expression like `a+b+` is entered. The current code won't build a list of used inputs when Math.js's `parse` function returns an error. These changes would build that list using an alternate method when `parse` fails.