### PR TITLE
fix: Edit Variable dialog displays read only expressions (PT-183974159)

### DIFF
--- a/src/diagram/components/dialog/dialog.scss
+++ b/src/diagram/components/dialog/dialog.scss
@@ -77,6 +77,7 @@ $invalid-outline: .5px solid vars.$invalid-red;
   max-width: calc(100% - 15px);
   overflow-y: scroll;
   padding: 3.5px 6px;
+  width: 100%;
 
   &.invalid {
     border: 1.5px solid vars.$invalid-red;

--- a/src/diagram/components/dialog/edit-variable-dialog.tsx
+++ b/src/diagram/components/dialog/edit-variable-dialog.tsx
@@ -69,6 +69,7 @@ export const EditVariableDialogContent = observer(({ variable, variableClone }: 
           disabled={isExpressionVariable}
           inputId="evd-units"
           label="Unit"
+          maxCharacters={27}
           value={isExpressionVariable ? variable.displayUnit || "" : variableClone.unit || ""}
           setValue={variableClone.setUnit}
         />


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183974159

This fixes two issues related to [this previous PR](https://github.com/concord-consortium/quantity-playground/pull/58).

1) The Name field was not expanding to the full width of its container.

2) The Unit field was not being limited to 27 characters.