### PR TITLE
fix: Edit Variable dialog displays read only expressions (PT-183974159)

### DIFF
--- a/cypress/integration/edit-variable-dialog.test.ts
+++ b/cypress/integration/edit-variable-dialog.test.ts
@@ -14,6 +14,7 @@ context("Test Edit Variable Dialog", () => {
   const nameField = () => cy.get("#evd-name");
   const valueField = () => cy.get("#evd-value");
   const notesField = () => cy.get("#evd-notes");
+  const unitsField = () => cy.get("#evd-units");
   describe("Edit Variable Dialog", () => {
     it("Edit variable button present and active when a node is selected", () => {
       editVariableButton().should("exist");
@@ -56,10 +57,16 @@ context("Test Edit Variable Dialog", () => {
       // After the value field has been blurred, it should switch to undefined
       valueField().should("have.value", "");
 
+      // Value and Unit fields should not allow line breaks
+      valueField().type("123{enter}456");
+      valueField().should("have.value", "123456");
+      unitsField().type("mp{enter}h");
+      unitsField().should("have.value", "mph");
+
       // Save changes and make sure the correct values have been saved
       editVariableOkButton().click();
       nodeToEdit().find(".name").should("have.value", nameNoSpaces);
-      nodeToEdit().find(".value").should("have.value", "");
+      nodeToEdit().find(".value").should("have.value", "123456");
       descriptionToggleButton().click();
       nodeToEdit().find(".variable-description-area").should("have.value", legalNotes);
     });

--- a/src/diagram/components/dialog/dialog.scss
+++ b/src/diagram/components/dialog/dialog.scss
@@ -75,7 +75,7 @@ $invalid-outline: .5px solid vars.$warning-purple;
   height: 14px;
   line-height: 1;
   max-width: calc(100% - 15px);
-  overflow-y: scroll;
+  overflow: hidden;
   padding: 3.5px 6px;
   width: 100%;
 

--- a/src/diagram/components/dialog/edit-variable-dialog.tsx
+++ b/src/diagram/components/dialog/edit-variable-dialog.tsx
@@ -70,6 +70,7 @@ export const EditVariableDialogContent = observer(({ variable, variableClone }: 
           inputId="evd-units"
           label="Unit"
           maxCharacters={27}
+          preventLineBreaks={true}
           value={isExpressionVariable ? variable.displayUnit || "" : variableClone.unit || ""}
           setValue={variableClone.setUnit}
         />
@@ -77,6 +78,7 @@ export const EditVariableDialogContent = observer(({ variable, variableClone }: 
           disabled={isExpressionVariable}
           inputId="evd-value"
           label="Value"
+          preventLineBreaks={true}
           realValue={isExpressionVariable ? variable?.displayValue : variableClone.value}
           setRealValue={variableClone.setValue}
         />

--- a/src/diagram/components/dialog/number-row.tsx
+++ b/src/diagram/components/dialog/number-row.tsx
@@ -12,13 +12,14 @@ interface INumberRow {
   disabled?: boolean;
   inputId: string;
   label: string;
+  preventLineBreaks?: boolean;
   realValue?: number;
   setRealValue: (value: number | undefined) => void;
   width?: number; // Width of text input
 }
 
 export const NumberRow = ({
-  className, disabled, inputId, label, realValue, width,
+  className, disabled, inputId, label, preventLineBreaks, realValue, width,
   setRealValue
 }: INumberRow) => {
   const style = { width };
@@ -29,6 +30,7 @@ export const NumberRow = ({
       isValid={isValidNumber}
       realValue={realValue}
       setRealValue={setRealValue}
+      preventLineBreaks={preventLineBreaks}
       otherProps={{ id: inputId, style }}
     />
   );

--- a/src/diagram/components/dialog/text-area-row.tsx
+++ b/src/diagram/components/dialog/text-area-row.tsx
@@ -11,15 +11,23 @@ interface ITextAreaRow {
   invalid?: boolean;
   label: string;
   maxCharacters?: number;
+  preventLineBreaks?: boolean;
   rows?: number;
   setValue?: (value: string) => void;
   spellCheck?: boolean;
   value: string;
 }
 export const TextAreaRow = ({
-  cols, disabled, inputId, invalid, label, maxCharacters, rows,
+  cols, disabled, inputId, invalid, label, maxCharacters, preventLineBreaks, rows,
   spellCheck, value, setValue
 }: ITextAreaRow) => {
+
+  const handleKeydown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (preventLineBreaks && e.key === "Enter") {
+      e.preventDefault();
+    }
+  };
+
   const classes = classNames("dialog-input dialog-textarea", { invalid });
   const content = (
     <textarea
@@ -30,6 +38,7 @@ export const TextAreaRow = ({
       maxLength={maxCharacters}
       value={value}
       onChange={setValue ? e => setValue(e.target.value) : undefined}
+      onKeyDown={handleKeydown}
       cols={cols}
       rows={rows}
       spellCheck={spellCheck}

--- a/src/diagram/components/ui/number-input.tsx
+++ b/src/diagram/components/ui/number-input.tsx
@@ -7,13 +7,14 @@ interface INumberInput {
   disabled?: boolean;
   isValid: (value: string) => boolean;
   otherProps?: Record<string, any>;
+  preventLineBreaks?: boolean;
   realValue?: number;
   setRealValue: (value: number | undefined) => void;
   onValueChange?: (evt: ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 export const NumberInput = ({
-  className, dataTestId, disabled, isValid, otherProps, realValue,
+  className, dataTestId, disabled, isValid, otherProps, preventLineBreaks, realValue,
   setRealValue, onValueChange
 }: INumberInput) => {
   const [value, setValue] = useState(realValue?.toString() || "");
@@ -24,6 +25,12 @@ export const NumberInput = ({
   const onChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
     onValueChange?.(e);
+  };
+
+  const handleKeydown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (preventLineBreaks && e.key === "Enter") {
+      e.preventDefault();
+    }
   };
 
   const onBlur = () => {
@@ -44,6 +51,7 @@ export const NumberInput = ({
       disabled={disabled}
       value={value}
       onChange={onChange}
+      onKeyDown={handleKeydown}
       onBlur={onBlur}
       {...otherProps}
       autoComplete="off"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/183974159

These changes specifically prevent line breaks in the variable edit dialog's Value and Unit fields whch was a follow up request made in a comment on the above PT story. Also included is a small style change to prevent scrollbars from appearing in textareas that do not yet have scrollable content.