### PR TITLE
Fix unit sluggishness

### DIFF
--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FocusEvent, MouseEvent, useState } from "react";
+import React, { ChangeEvent, FocusEvent, MouseEvent, useEffect, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { isAlive } from "mobx-state-tree";
 import { Handle, Position } from "react-flow-renderer/nocss";
@@ -26,6 +26,11 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
   const kDefaultExpandLength = 10;
   const kExpressionExpandLength = 18;
 
+  const [displayUnit, setDisplayUnit] = useState(variable.unit);
+  useEffect(() => {
+    setDisplayUnit(variable.unit);
+  }, [variable.unit]);
+
   const [showColorEditor, setShowColorEditor] = useState(false);
   const [showDescription, setShowDescription] = useState(false);
 
@@ -40,7 +45,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
   const hasExpression = !!(variable.numberOfInputs > 0);
   const errorMessage = variable.errorMessage;
   const shownValue = hasExpression ? variable.computedValue?.toString() || "" : variable.value;
-  const shownUnit = hasExpression ? variable.computedUnit : variable.unit;
+  const shownUnit = hasExpression ? variable.computedUnit : displayUnit;
 
   const handleEditColor = () => {
     setShowColorEditor(!showColorEditor);
@@ -50,11 +55,19 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     setShowDescription(!showDescription);
   };
 
-  const onUnitChange = (evt: ChangeEvent<HTMLTextAreaElement>) => {
+  const onUnitBlur = (evt: FocusEvent<HTMLTextAreaElement>) => {
     if (!evt.target.value) {
       variable.setUnit(undefined);
     } else {
       variable.setUnit(evt.target.value);
+    }
+  };
+
+  const onUnitChange = (evt: ChangeEvent<HTMLTextAreaElement>) => {
+    if (!evt.target.value) {
+      setDisplayUnit(undefined);
+    } else {
+      setDisplayUnit(evt.target.value);
     }
   };
 
@@ -125,6 +138,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
           placeholder="unit"
           title="unit"
           value={shownUnit || ""}
+          handleBlur={onUnitBlur}
           handleChange={onUnitChange}
           handleFocus={handleFieldFocus}
         />

--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -15,6 +15,7 @@ interface IProps {
   placeholder?: string;
   title: string;
   value?: string | number;
+  handleBlur?: (evt: FocusEvent<HTMLTextAreaElement>) => void;
   handleChange?: (evt: ChangeEvent<HTMLTextAreaElement>) => void;
   handleFocus?: (evt: FocusEvent<HTMLInputElement|HTMLTextAreaElement>|MouseEvent<HTMLInputElement|HTMLTextAreaElement>) => void;
   handleKeyDown?: (evt: React.KeyboardEvent) => void;
@@ -23,7 +24,7 @@ interface IProps {
 
 export const ExpandableInput = ({
   error, disabled, inputType, lengthToExpand, maxLength, placeholder, title, value,
-  handleChange, handleFocus, handleKeyDown, setRealValue
+  handleBlur, handleChange, handleFocus, handleKeyDown, setRealValue
 }: IProps) => {
 
   const isLongValue = (val: number | string | undefined, length: number) => {
@@ -86,6 +87,7 @@ export const ExpandableInput = ({
           data-testid={`variable-${title}`}
           disabled={disabled}
           maxLength={maxLength}
+          onBlur={handleBlur}
           onChange={onChange}
           onFocus={handleFocus}
           onKeyDown={handleKeyDown}

--- a/src/diagram/models/variable.ts
+++ b/src/diagram/models/variable.ts
@@ -58,20 +58,6 @@ export const Variable = types.model("Variable", {
   }
   return snClone;
 })
-.actions(self => ({
-  recreateMath() {
-    self.math = createMath();
-  }
-}))
-.actions(self => ({
-  afterCreate() {
-    // Update the math library whenever the custom units have changed.
-    addDisposer(self, reaction(
-      () => customUnitsArray.length,
-      () => self.recreateMath()
-    ));
-  }
-}))
 .views(self => ({
   get numberOfInputs() {
     const validInputs = self.inputs.filter(input => !!input);
@@ -82,6 +68,25 @@ export const Variable = types.model("Variable", {
   get hasInputs() {
     return self.numberOfInputs > 0;
   },
+}))
+.actions(self => ({
+  recreateMath() {
+    self.math = createMath();
+  }
+}))
+.actions(self => ({
+  afterCreate() {
+    // Update the math library whenever the custom units have changed.
+    addDisposer(self, reaction(
+      () => customUnitsArray.length,
+      () => {
+        // if (self.hasInputs) {
+          console.log(`recreating math for ${self.name} ${self.id}`);
+          self.recreateMath();
+        // }
+      }
+    ));
+  }
 }))
 .views(self => ({
   get inputNames() {

--- a/src/diagram/utils/mathjs-utils.ts
+++ b/src/diagram/utils/mathjs-utils.ts
@@ -21,6 +21,7 @@ export const getMathUnit = (value: number, unitString: string, mathLib: IMathLib
             const plural = pluralize.plural(symbol.name);
             const options = { aliases: [plural] };
             addCustomUnit(singular, options);
+            console.log(`adding ${singular}(${plural})`);
             mathLib.createUnit(singular, options);
           } else {
             addCustomUnit(symbol.name);


### PR DESCRIPTION
This PR fixes problems introduced with recent changes to how the mathjs library is replicated between different variables and updated. Those changes fixed a number of issues, but also made the diagram view run sluggishly, especially in the context of CLUE where many hidden variables are created.

- Only introduce new units when the unit field of a variable card is blurred, not on every keystroke.