### PR TITLE
fix: Clicking card fields should enable the edit button (PT-184565921)

### DIFF
--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -90,6 +90,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     // Stopping propagation allows the user to select text in the input field without 
     // inadvertently dragging the card/node.
     evt.stopPropagation();
+    data.dqRoot.setSelectedNode(data.node);
   };
 
   const renderValueUnitInput = (params: {disabled: boolean}) => {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184565921

Clicking into a variable card's fields wasn't causing the card to become selected which is the desired behavior. Among other features, when a card is selected, the Edit Variable button in the toolbar becomes enabled.

This change ensures that the card becomes selected when one of its fields comes into focus, causing the Edit Variable button to become enabled.