### PR TITLE
fix: Long values in variable dialog not displayed properly on card (PT-184474236)

### DIFF
--- a/src/diagram/components/ui/expandable-input.tsx
+++ b/src/diagram/components/ui/expandable-input.tsx
@@ -28,7 +28,7 @@ export const ExpandableInput = ({
 }: IProps) => {
 
   const isLongValue = (val: number | string | undefined, length: number) => {
-    return val && val.toString().length >= length;
+    return !!(val && val.toString().length >= length);
   };
 
   const [hasLongValue, setHasLongValue] = useState(isLongValue(value, lengthToExpand));
@@ -100,14 +100,12 @@ export const ExpandableInput = ({
     }
   };
 
-  // Ensure that hasLongValue is updated when the value changes in 
-  // disabled fields -- the onChange handler above does not get triggered
-  // by disabled fields.
+  // Ensure that hasLongValue is updated when the value changes. This is done separately
+  // from the onChange handler because the latter does not get triggered by disabled fields,
+  // nor when the value is set using the Edit Variable dialog.
   useEffect(() => {
-    if (disabled && value) {
-      setHasLongValue(isLongValue(value, lengthToExpand));
-    }
-  }, [disabled, lengthToExpand, value]);
+    setHasLongValue(isLongValue(value, lengthToExpand));
+  }, [lengthToExpand, value]);
 
   const containerClasses = classNames(
     "expandable-input-container",


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184474236

This change makes the ExpandableInput component properly update its styling for long values after the values are set using the Edit Variable dialog. Previously, if a long value was set in the Edit Variable dialog, the input field was not changing to indicate that the value was longer than the field.