### PR TITLE
184931580 Fix singular/plural unit bug

### DIFF
--- a/diagram-view/package.json
+++ b/diagram-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/diagram-view",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Concord Consortium Diagram View",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/diagram/utils/mathjs-utils.test.ts
+++ b/src/diagram/utils/mathjs-utils.test.ts
@@ -22,6 +22,9 @@ describe("mathjs-utils", () => {
       const singU = getMathUnit(0, "half", math);
       expect(singU && plurU?.equals(singU)).toBe(true);
     });
+    it("new unit with singular that is already a unit doesn't crash", () => {
+      expect(getMathUnit(0, "yds", math)).toBeTruthy();
+    });
     it("permits the '$' unit", () => {
       const u = getMathUnit(0,"$",math);
       expect(u?.toString()).toBe("0 $");

--- a/src/diagram/utils/mathjs-utils.ts
+++ b/src/diagram/utils/mathjs-utils.ts
@@ -19,9 +19,16 @@ export const getMathUnit = (value: number, unitString: string, mathLib: IMathLib
           if (/^[a-zA-Z]\w*$/.test(symbol.name)) {
             const singular = pluralize.singular(symbol.name);
             const plural = pluralize.plural(symbol.name);
-            const options = { aliases: [plural] };
-            addCustomUnit(singular, options);
-            mathLib.createUnit(singular, options);
+            if (mathLib.Unit.isValuelessUnit(singular) || mathLib.Unit.isValuelessUnit(plural)) {
+              // If the singular or plural is already a unit, just add the base
+              addCustomUnit(symbol.name);
+              mathLib.createUnit(symbol.name);
+            } else {
+              // Otherwise, add them both as synonyms
+              const options = { aliases: [plural] };
+              addCustomUnit(singular, options);
+              mathLib.createUnit(singular, options);
+            }
           } else {
             addCustomUnit(symbol.name);
             mathLib.createUnit(symbol.name);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184931580

The project team discovered a crashing bug related to adding new units to mathjs. When adding a new unit, our software would check to make sure the unit was not already in the mathjs system, but it would not check the plural/singular version of the unit. So it was possible to attempt to add a singular/plural version that was already in the system, even though the original unit was not.