### PR TITLE
fix: Undefined in expression calculation (PT-184955306)

### DIFF
--- a/src/diagram/models/variable.ts
+++ b/src/diagram/models/variable.ts
@@ -98,6 +98,7 @@ export const Variable = types.model("Variable", {
           if (node.type === "SymbolNode") {
             const inputs = self.inputs as IVariable[];
             const input = inputs.find(i => i.name === node.name);
+            if (!input) return node;
             return new SymbolNode(`${input?.computedValue} ${input?.computedUnit}`);
           } else {
             return node;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184955306

Adds a check to `calculationString` to make sure each node has an associated input. If not, it simply returns the node instead of attempting to return a non-existent value and unit. This fixes a bug where, for example, `calculationString` would convert an expression like `a+b in ft` to `10 cm + 10 mm in undefined undefined`. It will now correctly convert it to `10 cm + 10 mm in ft`.