### PR TITLE
184375687 Restrict Variable Names

### DIFF
--- a/cypress/integration/edit-variable-dialog.test.ts
+++ b/cypress/integration/edit-variable-dialog.test.ts
@@ -23,7 +23,7 @@ context("Test Edit Variable Dialog", () => {
       editVariableButton().should("not.be.disabled");
     });
     it("Dialog appears and works", () => {
-      const variableName = "variable-name";
+      const variableName = "variable_name";
       editVariableButton().click();
       editVariableDialog().should("exist");
       nameField().should("exist");

--- a/src/diagram/utils/mathjs-utils.ts
+++ b/src/diagram/utils/mathjs-utils.ts
@@ -4,6 +4,7 @@
 import math, { SymbolNode } from "mathjs";
 import * as pluralize from "pluralize";
 
+import { processName } from "./validate";
 import { addCustomUnit } from "../custom-mathjs-units";
 import { IMathLib } from "../custom-mathjs";
 
@@ -65,9 +66,11 @@ export const parseExpression = (expression: string, inputNames: (string | undefi
     // use a regex to find the input names in the expression.
     // Note there are slightly different subtract signs we need to handle.
     inputNames.forEach((name) => {
-      const variableRegex = new RegExp(`(^|[÷,×,+,-,-,/,*,),(,^])${name}([÷,×,+,-,-,/,*,(,),^]|$)`);
-      if (name && variableRegex.test(localExpression)) {
-        inputsInExpression.push(name);
+      if (name) {
+        const variableRegex = new RegExp(`(^|[÷,×,+,-,-,/,*,),(,^])${processName(name)}([÷,×,+,-,-,/,*,(,),^]|$)`);
+        if (name && variableRegex.test(localExpression)) {
+          inputsInExpression.push(name);
+        }
       }
     });
     return { expression: localExpression, inputsInExpression };

--- a/src/diagram/utils/validate.ts
+++ b/src/diagram/utils/validate.ts
@@ -7,7 +7,8 @@ export const isValidNumber = (v: string) => v !== "" && !isNaN(+v);
 // Only letters, digits, and underscores are allowed in variable names,
 // and the first character must be a letter.
 export const processName: (name: string) => string = name => (
-  name.length > 0 && name.match(/^[^a-zA-Z]\W*/)
+  // name.length > 0 && name.match(/^[^a-zA-Z]\W*/)
+  name.length > 0 && name.match(/^[^a-zA-Z]/)
   ? processName(name.slice(1))
   : name.replace(/\W/g, "")
 );

--- a/src/diagram/utils/validate.ts
+++ b/src/diagram/utils/validate.ts
@@ -4,4 +4,10 @@ export const kMaxNotesCharacters = 255;
 // We specifically disallow "", which converts to 0 when cast as a number
 export const isValidNumber = (v: string) => v !== "" && !isNaN(+v);
 
-export const processName = (name: string) => name.replace(/ /g, "");
+// Only letters, digits, and underscores are allowed in variable names,
+// and the first character must be a letter.
+export const processName: (name: string) => string = name => (
+  name.length > 0 && name.match(/^[^a-zA-Z]\W*/)
+  ? processName(name.slice(1))
+  : name.replace(/\W/g, "")
+);


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/184375687

This PR ensures that variable names can only include letters, digits, and underscores, and that they must begin with a letter. Characters entered into a variable card or dialog that do not meet these requirements are ignored.