### PR TITLE
Use concord version of mobx-state-tree.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
       - name: Install Dependencies
         run: npm ci
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: Install Dependencies
         run: npm ci
       - name: Build

--- a/diagram-view/package-lock.json
+++ b/diagram-view/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/diagram-view",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/diagram-view",
-      "version": "0.0.44",
+      "version": "0.0.45",
       "license": "MIT",
       "dependencies": {
         "iframe-phone": "^1.3.1",
@@ -14,6 +14,7 @@
         "reactflow": "^11.7.2"
       },
       "devDependencies": {
+        "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1",
         "@rollup/plugin-commonjs": "^21.0.2",
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@testing-library/jest-dom": "^5.16.2",
@@ -32,7 +33,6 @@
         "jest": "^27.5.1",
         "mobx": "^6.4.2",
         "mobx-react-lite": "^3.3.0",
-        "mobx-state-tree": "^5.1.3",
         "nanoid": "^3.3.1",
         "npm-run-all": "^4.1.5",
         "react": "^17.0.2",
@@ -51,9 +51,9 @@
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
+        "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1",
         "mobx": "^6.4.2",
         "mobx-react-lite": "^3.3.0",
-        "mobx-state-tree": "5.1.5",
         "nanoid": "^3.3.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -553,6 +553,19 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@concord-consortium/mobx-state-tree": {
+      "version": "5.1.8-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.1.8-cc.1.tgz",
+      "integrity": "sha512-2wdIWqGldMy7Gh/yV6MaFSGO1GcmEROmcRmVjvy1tYBtUSUj+CFnUiOep6RKScxY65slfR28SsiEHp/qyR3FNQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.3.0"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.0",
@@ -7277,19 +7290,6 @@
         }
       }
     },
-    "node_modules/mobx-state-tree": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.3.tgz",
-      "integrity": "sha512-noS6f0OG1T94Nlgq7Ex9k2JBGkoFclEdNLE5rlfOy5CUTzcHNJ18fu8t2TmGXDNzH/jdwc8xAR/w36A2XAUmwA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
-      },
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10702,6 +10702,13 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@concord-consortium/mobx-state-tree": {
+      "version": "5.1.8-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.1.8-cc.1.tgz",
+      "integrity": "sha512-2wdIWqGldMy7Gh/yV6MaFSGO1GcmEROmcRmVjvy1tYBtUSUj+CFnUiOep6RKScxY65slfR28SsiEHp/qyR3FNQ==",
+      "dev": true,
+      "requires": {}
     },
     "@eslint/eslintrc": {
       "version": "1.2.0",
@@ -15763,13 +15770,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.3.0.tgz",
       "integrity": "sha512-U/kMSFtV/bNVgY01FuiGWpRkaQVHozBq5CEBZltFvPt4FcV111hEWkgwqVg9GPPZSEuEdV438PEz8mk8mKpYlA==",
-      "dev": true,
-      "requires": {}
-    },
-    "mobx-state-tree": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.3.tgz",
-      "integrity": "sha512-noS6f0OG1T94Nlgq7Ex9k2JBGkoFclEdNLE5rlfOy5CUTzcHNJ18fu8t2TmGXDNzH/jdwc8xAR/w36A2XAUmwA==",
       "dev": true,
       "requires": {}
     },

--- a/diagram-view/package.json
+++ b/diagram-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/diagram-view",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "Concord Consortium Diagram View",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -40,16 +40,20 @@
     "type": "git",
     "url": "git+https://github.com/concord-consortium/quantity-playground.git"
   },
+  "overrides": {
+    "mobx-state-tree": "npm:@concord-consortium/mobx-state-tree@5.1.8-cc.1"
+  },
   "peerDependencies": {
+    "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1",
     "mobx": "^6.4.2",
     "mobx-react-lite": "^3.3.0",
-    "mobx-state-tree": "5.1.5",
     "nanoid": "^3.3.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "tslib": "^2.3.1"
   },
   "devDependencies": {
+    "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1",
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@testing-library/jest-dom": "^5.16.2",
@@ -68,7 +72,6 @@
     "jest": "^27.5.1",
     "mobx": "^6.4.2",
     "mobx-react-lite": "^3.3.0",
-    "mobx-state-tree": "^5.1.3",
     "nanoid": "^3.3.1",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1",
         "classnames": "^2.3.2",
         "iframe-phone": "^1.3.1",
         "mathjs": "^10.4.1",
         "mobx": "^6.4.2",
         "mobx-react-lite": "^3.3.0",
-        "mobx-state-tree": "^5.1.3",
         "nanoid": "^3.3.1",
         "patch-package": "^6.5.1",
         "pluralize": "^8.0.0",
@@ -1887,6 +1887,18 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@concord-consortium/mobx-state-tree": {
+      "version": "5.1.8-cc.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/mobx-state-tree/-/mobx-state-tree-5.1.8-cc.1.tgz",
+      "integrity": "sha512-2wdIWqGldMy7Gh/yV6MaFSGO1GcmEROmcRmVjvy1tYBtUSUj+CFnUiOep6RKScxY65slfR28SsiEHp/qyR3FNQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      },
+      "peerDependencies": {
+        "mobx": "^6.3.0"
+      }
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -14012,18 +14024,6 @@
         "react-native": {
           "optional": true
         }
-      }
-    },
-    "node_modules/mobx-state-tree": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.1.5.tgz",
-      "integrity": "sha512-jugIic0PYWW+nzzYfp4RUy9dec002Z778OC6KzoOyBHnqxupK9iPCsUJYkHjmNRHjZ8E4Z7qQpsKV3At/ntGVw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
-      },
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/module-deps": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less|sass|scss)$": "identity-obj-proxy"
+      "\\.(css|less|sass|scss)$": "identity-obj-proxy",
+      "mobx-state-tree": "@concord-consortium/mobx-state-tree"
     },
     "moduleFileExtensions": [
       "ts",
@@ -71,6 +72,9 @@
     "extends": "@istanbuljs/nyc-config-typescript",
     "all": true,
     "report-dir": "coverage-cypress"
+  },
+  "overrides": {
+    "mobx-state-tree": "npm:@concord-consortium/mobx-state-tree@5.1.8-cc.1"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.11",
@@ -125,12 +129,12 @@
     "webpack-dev-server": "^4.7.2"
   },
   "dependencies": {
+    "@concord-consortium/mobx-state-tree": "^5.1.8-cc.1",
     "classnames": "^2.3.2",
     "iframe-phone": "^1.3.1",
     "mathjs": "^10.4.1",
     "mobx": "^6.4.2",
     "mobx-react-lite": "^3.3.0",
-    "mobx-state-tree": "^5.1.3",
     "nanoid": "^3.3.1",
     "patch-package": "^6.5.1",
     "pluralize": "^8.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "./dist/",
     "sourceMap": true,
     "noImplicitAny": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "strict": true,
+    "paths": {
+      "mobx-state-tree": ["node_modules/@concord-consortium/mobx-state-tree/dist"]
+    },
     "types": ["jest", "@testing-library/jest-dom"],
     "jsx": "react",
     "lib": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,7 @@ module.exports = (env, argv) => {
                   plugins: [
                     {
                       // cf. https://github.com/svg/svgo/releases/tag/v2.4.0
-                      name: 'preset-default',
+                      name: "preset-default",
                       params: {
                         overrides: {
                           // don't minify "id"s (i.e. turn randomly-generated unique ids into "a", "b", ...)
@@ -130,6 +130,9 @@ module.exports = (env, argv) => {
       ]
     },
     resolve: {
+      alias: {
+        "mobx-state-tree": "@concord-consortium/mobx-state-tree"
+      },
       extensions: [ ".ts", ".tsx", ".js" ]
     },
     // stats: {


### PR DESCRIPTION
Updates `quantity-playground` and `diagram-view` to use Concord Consortium's version of `mobx-state-tree`.