### PR TITLE
185298503 Highlight selected arrows

### DIFF
--- a/src/diagram/components/diagram.scss
+++ b/src/diagram/components/diagram.scss
@@ -31,7 +31,8 @@
 
   &.selected {
     .react-flow__edge-path {
-      marker-end: url("#custom-arrow__selected-or-used");
+      stroke: $select-blue;
+      marker-end: url("#custom-arrow__dragging");
     }
   }
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185298503

This PR makes selected arrows/connections/edges in `diagram-view` blue rather than dark gray.