### PR TITLE
185298570 Make it easier to connect nodes

### DIFF
--- a/src/diagram/components/quantity-node.scss
+++ b/src/diagram/components/quantity-node.scss
@@ -1,9 +1,10 @@
 @import "../../scss/vars.scss";
 @import "../../scss/mixins.scss";
 
-// Make sure to update kDefaultNodeWidth and kDefaultNodeHeight in models/dq-node.ts when you change these constants.
+// Make sure to update corresponding constants in models/dq-node.ts when you change these constants.
 $node-width: 194px;
 $node-height: 98px;
+$node-row-height: 26px;
 
 $node-inner-width: 164px;
 $input-half-width: calc(($node-inner-width/2) - 2px);
@@ -107,7 +108,7 @@ $color-gray-dark: #3f3f3f;
   gap: 6px;
   height: auto;
   margin-bottom: 6px;
-  min-height: 26px;
+  min-height: $node-row-height;
   position: relative;
 
   &.name-row { border: solid 2px white; }
@@ -177,7 +178,7 @@ $color-gray-dark: #3f3f3f;
       border-radius: 5px;
       font-family: $default-font-family;
       font-size: 14px;
-      min-height: 26px;
+      min-height: $node-row-height;
       overflow-y: scroll;
       padding: 3.5px 6px;
       resize: none;
@@ -195,7 +196,7 @@ $color-gray-dark: #3f3f3f;
     color: $default-fg-color;
     display: flex;
     font-size: 14px;
-    height: 26px;
+    height: $node-row-height;
     text-align: left;
     white-space: nowrap;
 

--- a/src/diagram/components/quantity-node.tsx
+++ b/src/diagram/components/quantity-node.tsx
@@ -6,7 +6,7 @@ import TextareaAutosize from "react-textarea-autosize";
 import classNames from "classnames";
 
 import { ColorEditor } from "./color-editor";
-import { DQNodeType } from "../models/dq-node";
+import { DQNodeType, kDefaultNodeHeight, kDefaultNodeRowHeight, kDefaultNodeWidth, kExpandedNotesHeight } from "../models/dq-node";
 import { DQRootType } from "../models/dq-root";
 import { kMaxNameCharacters, kMaxNotesCharacters, processName } from "../utils/validate";
 import { ExpandableInput } from "./ui/expandable-input";
@@ -131,11 +131,20 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
     );
   };
 
-  const nodeHeight = hasExpression ? "155px" : "120px";
-  const nodeWidth = "220px";
-  const targetNodeHandleStyle = data.dqRoot.connectingVariable && data.dqRoot.connectingVariable !== variable
-                                  ? {height: nodeHeight, width: nodeWidth, left: "1px", opacity: 0, borderRadius: 0}
-                                  : {height: nodeHeight, width: nodeWidth, left: "1px", opacity: 0, borderRadius: 0, pointerEvents: ("none" as React.CSSProperties["pointerEvents"])};
+  const yPadding = 15;
+  const nodeHeight =
+    kDefaultNodeHeight
+    + (showDescription ? kExpandedNotesHeight : 0)
+    + (hasExpression ? kDefaultNodeRowHeight : 0)
+    + 2 * yPadding;
+  const targetHeight = `${nodeHeight}px`;
+  const xPadding = 15;
+  const targetWidth = `${kDefaultNodeWidth + 2 * xPadding}px`;
+  const basicNodeHandleStyle = {height: targetHeight, width: targetWidth, left: `-${xPadding}px`, opacity: 0, borderRadius: 0};
+  const allowPointerEvents = data.dqRoot.connectingVariable && data.dqRoot.connectingVariable !== variable;
+  const pointerEventStyle = allowPointerEvents ? {} : { pointerEvents: ("none" as React.CSSProperties["pointerEvents"]) };
+  const targetNodeHandleStyle = { ...basicNodeHandleStyle, ...pointerEventStyle };
+
   const sourceHandleStyle = {border: "none", borderRadius: "50%", width: "12px", height: "12px", background: "#949494", right: "-5px"};
 
   const nodeContainerClasses = classNames(variable.color, "node-container");
@@ -207,7 +216,7 @@ const _QuantityNode: React.FC<IProps> = ({ data, isConnectable }) => {
         <Handle
           type="target"
           position={Position.Left}
-          style={{...targetNodeHandleStyle}}
+          style={targetNodeHandleStyle}
           isConnectable={isConnectable}
           id="a" // is this supposed to be here?
         />

--- a/src/diagram/models/dq-node.ts
+++ b/src/diagram/models/dq-node.ts
@@ -3,8 +3,12 @@ import { nanoid } from "nanoid";
 import { Edge, Node, MarkerType } from "reactflow";
 import { Variable, VariableType } from "./variable";
 
+// Make sure to update corresponding variables in components/quantity-node.scss when you change these constants.
 export const kDefaultNodeWidth = 194;
 export const kDefaultNodeHeight = 98;
+export const kDefaultNodeRowHeight = 26;
+
+export const kExpandedNotesHeight = 67;
 
 export const DQNode = types.model("DQNode", {
   id: types.optional(types.identifier, () => nanoid(16)),


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185298570

This PR makes it easier to establish a connection between two nodes by expanding the target area to drop a new arrow/connection/edge to be larger than the node. It also does a better job of approximating the height of a node.