### PR TITLE
185375603 Adjust reactflow viewport when the model's viewport changes.

### DIFF
--- a/diagram-view/package-lock.json
+++ b/diagram-view/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@concord-consortium/diagram-view",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@concord-consortium/diagram-view",
-      "version": "0.0.47",
+      "version": "0.0.48",
       "license": "MIT",
       "dependencies": {
         "iframe-phone": "^1.3.1",

--- a/diagram-view/package.json
+++ b/diagram-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/diagram-view",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "Concord Consortium Diagram View",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/diagram/components/diagram.tsx
+++ b/src/diagram/components/diagram.tsx
@@ -57,21 +57,18 @@ export const _Diagram = ({ dqRoot, getDiagramExport, hideControls, hideNavigator
 
   // Update the viewport when the model's viewport changes (for example, when undoing)
   useEffect(() => {
-    console.log(`--- useEffect`);
     const lastViewport = rfInstance?.getViewport();
     const modelViewport = dqRoot.flowTransform;
-    console.log(`  - rfInstance.getViewport`, lastViewport);
-    console.log(`  - dqRoot.flowTransform`, modelViewport);
-    if (lastViewport && modelViewport) {
-      console.log(`  - equal`, viewportsEqual(lastViewport, modelViewport));
-      if (!viewportsEqual(lastViewport, modelViewport)) {
-        rfInstance.setViewport(modelViewport);
-      }
+    if (lastViewport && modelViewport && !viewportsEqual(lastViewport, modelViewport)) {
+      rfInstance.setViewport(modelViewport);
     }
   }, [dqRoot.flowTransform, rfInstance]);
 
+  // TODO This is only being called when the user pans, but should be called in other contexts
+  // (for example, pinching to zoom)
   const handleViewportChange = (event: MouseEvent | TouchEvent, viewport: Viewport) => {
-    if (!viewportsEqual(viewport, dqRoot.flowTransform as Viewport)) {
+    const rootViewport = dqRoot.flowTransform as Viewport;
+    if (rootViewport && !viewportsEqual(viewport, rootViewport)) {
       dqRoot.setTransform(viewport);
     }
   };

--- a/src/diagram/utils/diagram-helper.ts
+++ b/src/diagram/utils/diagram-helper.ts
@@ -1,28 +1,36 @@
 import { kDefaultNodeWidth, kDefaultNodeHeight } from "../models/dq-node";
+import { DQRootType } from "../models/dq-root";
 
 // A class to give clients access to functions that modify or access private information from a diagram
 export class DiagramHelper {
   reactFlowWrapper: any;
   rfInstance: any;
+  dqRoot: DQRootType;
 
-  constructor(_reactFlowWrapper: any, _rfInstance: any) {
+  constructor(_reactFlowWrapper: any, _rfInstance: any, _dqRoot: DQRootType) {
     this.reactFlowWrapper = _reactFlowWrapper;
     this.rfInstance = _rfInstance;
+    this.dqRoot = _dqRoot;
+  }
+
+  // TODO Zoom in and zoom out are not properly saving changes to the dqRoot
+  changeView(func: () => void) {
+    func();
+    const newView = this.rfInstance.getViewport();
+    this.dqRoot.setTransform(newView);
+    return newView;
   }
 
   fitView() {
-    this.rfInstance.fitView();
-    return this.rfInstance.getViewport();
+    return this.changeView(this.rfInstance.fitView);
   }
 
   zoomIn() {
-    this.rfInstance.zoomIn();
-    return this.rfInstance.getViewport();
+    return this.changeView(this.rfInstance.zoomIn);
   }
 
   zoomOut() {
-    this.rfInstance.zoomOut();
-    return this.rfInstance.getViewport();
+    return this.changeView(this.rfInstance.zoomOut);
   }
 
   convertClientToDiagramPosition({x, y}: {x: number, y: number}) {

--- a/src/diagram/utils/reactflow-utils.ts
+++ b/src/diagram/utils/reactflow-utils.ts
@@ -1,0 +1,5 @@
+import { Viewport } from "reactflow";
+
+export function viewportsEqual(v1: Viewport, v2: Viewport) {
+  return v1.x === v2.x && v1.y === v2.y && v1.zoom === v2.zoom;
+}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185375603

This PR partially solves the issue of updating the `reactflow` viewport when the model changes (such as undoing a pan or zoom). The solution is only partial because I ran out of time working on it. Outstanding issues:
- Zoom in/zoom out do not properly undo/redo after the initial undo. It seems like the viewport change is not being correctly recorded in these cases.
- There are probably some user actions (like pinching to zoom) that are not being recorded, but I didn't even have time to look at these cases.