### PR TITLE
185855379 Adjust Zooming and Panning

### DIFF
--- a/diagram-view/package.json
+++ b/diagram-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/diagram-view",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Concord Consortium Diagram View",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/diagram/components/diagram.tsx
+++ b/src/diagram/components/diagram.tsx
@@ -224,6 +224,7 @@ export const _Diagram = ({ dqRoot, getDiagramExport, hideControls, hideNavigator
           edgeTypes={edgeTypes}
           edgesUpdatable={false}
           elementsSelectable={interactive}
+          minZoom={.001}
           nodes={rfNodes}
           nodesConnectable={interactive}
           nodesDraggable={interactive}

--- a/src/diagram/components/diagram.tsx
+++ b/src/diagram/components/diagram.tsx
@@ -218,13 +218,14 @@ export const _Diagram = ({ dqRoot, getDiagramExport, hideControls, hideNavigator
       <ReactFlowProvider>
         <ReactFlow
           attributionPosition="bottom-left"
+          autoPanOnNodeDrag={false}
           connectionLineComponent={ConnectionLine}
           defaultViewport={defaultViewport}
           edges={rfEdges}
           edgeTypes={edgeTypes}
           edgesUpdatable={false}
           elementsSelectable={interactive}
-          minZoom={.001}
+          minZoom={.1}
           nodes={rfNodes}
           nodesConnectable={interactive}
           nodesDraggable={interactive}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/185855379

This PR adjusts the zooming and panning of ReactFlow to avoid situations where students couldn't see their entire diagram layout in a single screen, even when pushing the fit all button.
- Minimum zoom has been changed from .5 to .1, so 25x as much of the area can be shown at once.
- Dragging a node to the edge of the screen no longer pans the screen, which is how many students would find themselves in situations where nodes were very far apart from each other.