### PR TITLE
ignore unused inputs when checking validity

### DIFF
--- a/src/diagram/models/variable.test.ts
+++ b/src/diagram/models/variable.test.ts
@@ -114,6 +114,38 @@ describe("Variable", () => {
     expect(variable.computedUnitIncludingMessageAndError).toEqual({});
   });
 
+  it("with 2 inputs one of which is valueless, result is valueless", () => {
+    const container = GenericContainer.create({
+      items: [
+        {id: "inputA", name: "a", value: 111.1},
+        {id: "inputB", name: "b"},
+        {id: "variable", value: 123.5, unit: "m", inputs: ["inputA", "inputB"], expression: "a+b"}
+      ]
+    });
+    const variable = container.items[2] as VariableType;
+
+    expect(variable.numberOfInputs).toBe(2);
+    expect(variable.computedValueIncludingMessageAndError).toEqual({});
+    expect(variable.computedValueIncludingMessageAndError.error?.short).toBeUndefined();
+    expect(variable.computedValue).toBeUndefined();
+  });
+
+  it("with 2 inputs only one of which is used, the other can be valueless", () => {
+    const container = GenericContainer.create({
+      items: [
+        {id: "inputA", name: "a", value: 111.1},
+        {id: "inputB", name: "b"},
+        {id: "variable", value: 123.5, unit: "m", inputs: ["inputA", "inputB"], expression: "a"}
+      ]
+    });
+    const variable = container.items[2] as VariableType;
+
+    expect(variable.numberOfInputs).toBe(2);
+    expect(variable.computedValueIncludingMessageAndError).toEqual({value: 111.1});
+  });
+
+
+
   it("with 2 inputs and operation Multiply it returns result", () => {
     const container = GenericContainer.create({
       items: [

--- a/src/diagram/models/variable.ts
+++ b/src/diagram/models/variable.ts
@@ -168,16 +168,15 @@ export const Variable = types.model("Variable", {
         continue;
       }
 
-      // TODO: you can make an expression that only uses one input and the other
-      // input is connected but not used. In that case the unused input should be skipped.
-      //
-      // Currently if an unused input doesn't have a value, the output will show
-      // NaN because of the validation below.
-
       // The mathValue could be a number so a falsy check can't be used
       try {
         if (input.mathValue !== undefined) {
-          // this input should be fine
+          // Input has a value; it should be fine
+          continue;
+        }
+        if (!input.name || !self.inputsInExpression?.includes(input.name)) {
+          // Undefined is also fine if the connected input is not actually used in the expression.
+          // If it has no name, it _cannot_ be used.
           continue;
         }
       } catch (error) {


### PR DESCRIPTION
Fixes PT-186817666 

The bug report corresponded to a TODO in the file. Instead of bailing out any time an input has no value, first check whether that input is actually used.
