### PR TITLE
don't register empty string units

### DIFF
--- a/src/diagram/units-manager.ts
+++ b/src/diagram/units-manager.ts
@@ -198,7 +198,3 @@ export const deleteUnits = [
   // Binary
   "b", "bit", "bits", "B", "byte", "bytes",
 ];
-
-function isValidUnitName(name: string) {
-  return /^[a-zA-Z]\w*$/.test(name);
-}

--- a/src/diagram/utils/mathjs-utils.test.ts
+++ b/src/diagram/utils/mathjs-utils.test.ts
@@ -27,6 +27,10 @@ describe("mathjs-utils", () => {
     it("new unit with singular that is already a unit doesn't crash", () => {
       expect(unitsManager.getMathUnit(0, "yds", math)).toBeTruthy();
     });
+    it("permits the 'S' unit even though pluralize returns '' for the singluar", () => {
+      const u = unitsManager.getMathUnit(0,"S",math);
+      expect(u?.toString()).toBe("0 S");
+    });
     it("permits the '$' unit", () => {
       const u = unitsManager.getMathUnit(0,"$",math);
       expect(u?.toString()).toBe("0 $");


### PR DESCRIPTION
- pluarlize returns an empty string singular for "S"
- in that case just register the initial unit ("S") instead of an aliased unit
- remove the try catch around creating the unit. This same try catch was not in place when the units were created in initializeMath, so this way we'll fail faster if there are more cases we haven't handled yet.
- unify the combination of addUnit and createUnit so the code is more clear.