### PR TITLE
better invalid unit error handling

### DIFF
--- a/src/diagram/custom-math-js.test.ts
+++ b/src/diagram/custom-math-js.test.ts
@@ -1,9 +1,18 @@
 import { createMath } from "./custom-mathjs";
 import { UnitsManager } from "./units-manager";
+import { IMathLib } from "./utils/mathjs-utils";
 
 describe("MathJS", () => {
-  const unitsManager = new UnitsManager();
-  const { evaluate, unit } = createMath(unitsManager);
+  let unitsManager: UnitsManager;
+  let evaluate: IMathLib["evaluate"];
+  let unit: IMathLib["unit"];
+
+  beforeEach(() => {
+    unitsManager = new UnitsManager();
+    const math = createMath(unitsManager);
+    evaluate = math.evaluate;
+    unit = math.unit;
+  });
 
   it("can handle unit conversion with evaluate and unit values", () => {
     const scope = {
@@ -211,6 +220,40 @@ describe("MathJS", () => {
       const result = localMath.evaluate("a*b", scope);
       const simpl = result.simplify();
       expect(simpl.toString()).toEqual("1 m");
+    });
+
+    it("handles '_'", () => {
+      unitsManager.addUnit("t_s");
+      const localMath = createMath(unitsManager);
+      const scope = {
+        a: localMath.unit(1, "m/t_s"),
+        b: localMath.unit(1, "t_s")
+      };
+      const result = localMath.evaluate("a*b", scope);
+      const simpl = result.simplify();
+      expect(simpl.toString()).toEqual("1 m");
+    });
+
+    // This section describes the valid variable characters:
+    // https://mathjs.org/docs/expressions/syntax.html#constants-and-variables
+    it("handles a valid variable which is an invalid unit", () => {
+      unitsManager.addUnit("Ā");
+      const localMath = createMath(unitsManager);
+      const scope = {
+        a: localMath.unit(1, "m")
+      };
+      const result = localMath.evaluate("a", scope);
+      expect(result.toString()).toEqual("1 m");
+    });
+
+    it("handles an invalid variable", () => {
+      unitsManager.addUnit("✔");
+      const localMath = createMath(unitsManager);
+      const scope = {
+        a: localMath.unit(1, "m")
+      };
+      const result = localMath.evaluate("a", scope);
+      expect(result.toString()).toEqual("1 m");
     });
 
     it("handles units with options", () => {


### PR DESCRIPTION
- the UnitManager now doesn't crash when initializeMath is called and there is an invalid unit
- the `_` char is explicitly allowed to be a unit character
- invalid units are not added to the unit manager
- updated custom-math test so each test is isolated with its own instance of the units manager.
- removed what seemed like an unnecessary explicit "addUnit" call in variable.test.ts
- grouped invalid unit tests in variable.test.ts
- added tests for invalid characters of various types.